### PR TITLE
Adding support proxy providers (subscriptions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.vscode/
 /vendor/
 /*.json
 /*.srs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode/
 /vendor/
 /*.json
+/*.txt
 /*.srs
 /*.db
 /site/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Sing-box with extended features.
 * SDNS (DNSCrypt)
 * Extended Wireguard options
 * Unified delay
+* Subscription providers
 
 ## Examples
 

--- a/adapter/experimental.go
+++ b/adapter/experimental.go
@@ -59,6 +59,8 @@ type CacheFile interface {
 	SaveRuleSet(tag string, set *SavedBinary) error
 	LoadWARPConfig(tag string) *SavedBinary
 	SaveWARPConfig(tag string, set *SavedBinary) error
+	LoadSubscription(tag string) *SavedBinary
+	SaveSubscription(tag string, sub *SavedBinary) error
 }
 
 type SavedBinary struct {

--- a/adapter/provider.go
+++ b/adapter/provider.go
@@ -1,0 +1,51 @@
+package adapter
+
+import (
+	"context"
+	"time"
+
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/x/list"
+)
+
+type Provider interface {
+	Type() string
+	Tag() string
+	Outbounds() []Outbound
+	Outbound(tag string) (Outbound, bool)
+	UpdatedAt() time.Time
+	HealthCheck(ctx context.Context) (map[string]uint16, error)
+	RegisterCallback(callback ProviderUpdateCallback) *list.Element[ProviderUpdateCallback]
+	UnregisterCallback(element *list.Element[ProviderUpdateCallback])
+}
+
+type ProviderUpdater interface {
+	Update() error
+}
+
+type ProviderSubscriptionInfo interface {
+	SubscriptionInfo() SubscriptionInfo
+}
+
+type ProviderRegistry interface {
+	option.ProviderOptionsRegistry
+	CreateProvider(ctx context.Context, router Router, logFactory log.Factory, tag string, providerType string, options any) (Provider, error)
+}
+
+type ProviderManager interface {
+	Lifecycle
+	Providers() []Provider
+	Get(tag string) (Provider, bool)
+	Remove(tag string) error
+	Create(ctx context.Context, router Router, logFactory log.Factory, tag string, providerType string, options any) error
+}
+
+type SubscriptionInfo struct {
+	Upload   int64
+	Download int64
+	Total    int64
+	Expire   int64
+}
+
+type ProviderUpdateCallback = func(tag string) error

--- a/adapter/provider/adapter.go
+++ b/adapter/provider/adapter.go
@@ -1,0 +1,267 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/urltest"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/batch"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/x/list"
+	"github.com/sagernet/sing/service"
+)
+
+type Adapter struct {
+	ctx            context.Context
+	outbound       adapter.OutboundManager
+	router         adapter.Router
+	logFactory     log.Factory
+	logger         log.ContextLogger
+	providerType   string
+	providerTag    string
+	outbounds      []adapter.Outbound
+	outboundsByTag map[string]adapter.Outbound
+	ticker         *time.Ticker
+	checking       atomic.Bool
+	history        adapter.URLTestHistoryStorage
+	callbackAccess sync.Mutex
+	callbacks      list.List[adapter.ProviderUpdateCallback]
+
+	link     string
+	enabled  bool
+	timeout  time.Duration
+	interval time.Duration
+}
+
+func NewAdapter(ctx context.Context, router adapter.Router, outbound adapter.OutboundManager, logFactory log.Factory, logger log.ContextLogger, providerTag string, providerType string, options option.ProviderHealthCheckOptions) Adapter {
+	timeout := time.Duration(options.Timeout)
+	if timeout == 0 {
+		timeout = 3 * time.Second
+	}
+	interval := time.Duration(options.Interval)
+	if interval == 0 {
+		interval = 10 * time.Minute
+	}
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+	return Adapter{
+		ctx:          ctx,
+		outbound:     outbound,
+		router:       router,
+		logFactory:   logFactory,
+		logger:       logger,
+		providerType: providerType,
+		providerTag:  providerTag,
+
+		enabled:  options.Enabled,
+		link:     options.URL,
+		timeout:  timeout,
+		interval: interval,
+	}
+}
+
+func (a *Adapter) Start() error {
+	a.history = service.FromContext[adapter.URLTestHistoryStorage](a.ctx)
+	if a.history == nil {
+		if clashServer := service.FromContext[adapter.ClashServer](a.ctx); clashServer != nil {
+			a.history = clashServer.HistoryStorage()
+		} else {
+			a.history = urltest.NewHistoryStorage()
+		}
+	}
+	go a.loopCheck()
+	return nil
+}
+
+func (a *Adapter) Type() string {
+	return a.providerType
+}
+
+func (a *Adapter) Tag() string {
+	return a.providerTag
+}
+
+func (a *Adapter) Outbounds() []adapter.Outbound {
+	return a.outbounds
+}
+
+func (a *Adapter) Outbound(tag string) (adapter.Outbound, bool) {
+	if a.outboundsByTag == nil {
+		return nil, false
+	}
+	detour, ok := a.outboundsByTag[tag]
+	return detour, ok
+}
+
+func (a *Adapter) UpdateOutbounds(oldOpts []option.Outbound, newOpts []option.Outbound) {
+	a.removeUseless(newOpts)
+	var (
+		oldOptByTag    = make(map[string]option.Outbound)
+		outbounds      = make([]adapter.Outbound, 0, len(newOpts))
+		outboundsByTag = make(map[string]adapter.Outbound)
+	)
+	for _, opt := range oldOpts {
+		oldOptByTag[opt.Tag] = opt
+	}
+	for i, opt := range newOpts {
+		var tag string
+		if opt.Tag != "" {
+			tag = F.ToString(a.providerTag, "/", opt.Tag)
+		} else {
+			tag = F.ToString(a.providerTag, "/", i)
+		}
+		outbound, exist := a.outbound.Outbound(tag)
+		if !exist || !reflect.DeepEqual(opt, oldOptByTag[opt.Tag]) {
+			err := a.outbound.Create(
+				adapter.WithContext(a.ctx, &adapter.InboundContext{
+					Outbound: tag,
+				}),
+				a.router,
+				a.logFactory.NewLogger(F.ToString("outbound/", opt.Type, "[", tag, "]")),
+				tag,
+				opt.Type,
+				opt.Options,
+			)
+			if err != nil {
+				a.logger.Warn(err, " in ", tag, ", skip create this outbound")
+				continue
+			}
+			outbound, _ = a.outbound.Outbound(tag)
+		}
+		outbounds = append(outbounds, outbound)
+		outboundsByTag[tag] = outbound
+	}
+	if a.enabled && a.history != nil {
+		go a.HealthCheck(a.ctx)
+	}
+	a.outbounds = outbounds
+	a.outboundsByTag = outboundsByTag
+}
+
+func (a *Adapter) HealthCheck(ctx context.Context) (map[string]uint16, error) {
+	if a.ticker != nil {
+		a.ticker.Reset(a.interval)
+	}
+	return a.healthcheck(ctx)
+}
+
+func (a *Adapter) RegisterCallback(callback adapter.ProviderUpdateCallback) *list.Element[adapter.ProviderUpdateCallback] {
+	a.callbackAccess.Lock()
+	defer a.callbackAccess.Unlock()
+	return a.callbacks.PushBack(callback)
+}
+
+func (a *Adapter) UnregisterCallback(element *list.Element[adapter.ProviderUpdateCallback]) {
+	a.callbackAccess.Lock()
+	defer a.callbackAccess.Unlock()
+	a.callbacks.Remove(element)
+}
+
+func (a *Adapter) UpdateGroups() {
+	for element := a.callbacks.Front(); element != nil; element = element.Next() {
+		element.Value(a.providerTag)
+	}
+}
+
+func (a *Adapter) Close() error {
+	if a.ticker != nil {
+		a.ticker.Stop()
+	}
+	outbounds := a.outbounds
+	a.outbounds = nil
+	var err error
+	for _, ob := range outbounds {
+		if err2 := a.outbound.Remove(ob.Tag()); err2 != nil {
+			err = E.Append(err, err2, func(err error) error {
+				return E.Cause(err, "close outbound [", ob.Tag(), "]")
+			})
+		}
+	}
+	return err
+}
+
+func (a *Adapter) loopCheck() {
+	if !a.enabled {
+		return
+	}
+	a.ticker = time.NewTicker(a.interval)
+	a.healthcheck(a.ctx)
+	for {
+		select {
+		case <-a.ctx.Done():
+			return
+		case <-a.ticker.C:
+			a.healthcheck(a.ctx)
+		}
+	}
+}
+
+func (a *Adapter) healthcheck(ctx context.Context) (map[string]uint16, error) {
+	result := make(map[string]uint16)
+	if a.checking.Swap(true) {
+		return result, nil
+	}
+	defer a.checking.Store(false)
+	b, _ := batch.New(ctx, batch.WithConcurrencyNum[any](10))
+	var resultAccess sync.Mutex
+	checked := make(map[string]bool)
+	for _, detour := range a.outbounds {
+		tag := detour.Tag()
+		if checked[tag] {
+			continue
+		}
+		checked[tag] = true
+		b.Go(tag, func() (any, error) {
+			ctx, cancel := context.WithTimeout(a.ctx, a.timeout)
+			defer cancel()
+			t, err := urltest.URLTest(ctx, a.link, detour)
+			if err != nil {
+				a.logger.Debug("outbound ", tag, " unavailable: ", err)
+				a.history.DeleteURLTestHistory(tag)
+			} else {
+				a.logger.Debug("outbound ", tag, " available: ", t, "ms")
+				a.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{
+					Time:  time.Now(),
+					Delay: t,
+				})
+				resultAccess.Lock()
+				result[tag] = t
+				resultAccess.Unlock()
+			}
+			return nil, nil
+		})
+	}
+	b.Wait()
+	return result, nil
+}
+
+func (a *Adapter) removeUseless(newOpts []option.Outbound) {
+	if len(a.outbounds) == 0 {
+		return
+	}
+	exists := make(map[string]bool)
+	for i, opt := range newOpts {
+		var tag string
+		if opt.Tag != "" {
+			tag = F.ToString(a.providerTag, "/", opt.Tag)
+		} else {
+			tag = F.ToString(a.providerTag, "/", i)
+		}
+		exists[tag] = true
+	}
+	for _, opt := range a.outbounds {
+		if !exists[opt.Tag()] {
+			if err := a.outbound.Remove(opt.Tag()); err != nil {
+				a.logger.Error(err, "close outbound [", opt.Tag(), "]")
+			}
+		}
+	}
+}

--- a/adapter/provider/manager.go
+++ b/adapter/provider/manager.go
@@ -1,0 +1,157 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/taskmonitor"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+)
+
+var _ adapter.ProviderManager = (*Manager)(nil)
+
+type Manager struct {
+	logger        log.ContextLogger
+	registry      adapter.ProviderRegistry
+	access        sync.Mutex
+	started       bool
+	stage         adapter.StartStage
+	providers     []adapter.Provider
+	providerByTag map[string]adapter.Provider
+	wg            sync.WaitGroup
+}
+
+func NewManager(logger logger.ContextLogger, registry adapter.ProviderRegistry) *Manager {
+	return &Manager{
+		logger:        logger,
+		registry:      registry,
+		providerByTag: make(map[string]adapter.Provider),
+	}
+}
+
+func (m *Manager) Initialize() {
+}
+
+func (m *Manager) Start(stage adapter.StartStage) error {
+	m.access.Lock()
+	if m.started && m.stage >= stage {
+		panic("already started")
+	}
+	m.started = true
+	m.stage = stage
+	providers := m.providers
+	m.access.Unlock()
+	for _, provider := range providers {
+		err := adapter.LegacyStart(provider, stage)
+		if err != nil {
+			return E.Cause(err, stage, " provider/", provider.Type(), "[", provider.Tag(), "]")
+		}
+	}
+	return nil
+}
+
+func (m *Manager) Close() error {
+	monitor := taskmonitor.New(m.logger, C.StopTimeout)
+	m.access.Lock()
+	if !m.started {
+		m.access.Unlock()
+		return nil
+	}
+	m.started = false
+	providers := m.providers
+	m.providers = nil
+	m.access.Unlock()
+	var err error
+	for _, provider := range providers {
+		if closer, isCloser := provider.(io.Closer); isCloser {
+			monitor.Start("close provider/", provider.Type(), "[", provider.Tag(), "]")
+			err = E.Append(err, closer.Close(), func(err error) error {
+				return E.Cause(err, "close provider/", provider.Type(), "[", provider.Tag(), "]")
+			})
+			monitor.Finish()
+		}
+	}
+	return nil
+}
+
+func (m *Manager) Providers() []adapter.Provider {
+	m.access.Lock()
+	defer m.access.Unlock()
+	return m.providers
+}
+
+func (m *Manager) Get(tag string) (adapter.Provider, bool) {
+	m.access.Lock()
+	provider, found := m.providerByTag[tag]
+	m.access.Unlock()
+	return provider, found
+}
+
+func (m *Manager) Remove(tag string) error {
+	m.access.Lock()
+	provider, found := m.providerByTag[tag]
+	if !found {
+		m.access.Unlock()
+		return os.ErrInvalid
+	}
+	delete(m.providerByTag, tag)
+	index := common.Index(m.providers, func(it adapter.Provider) bool {
+		return it == provider
+	})
+	if index == -1 {
+		panic("invalid provider index")
+	}
+	m.providers = append(m.providers[:index], m.providers[index+1:]...)
+	started := m.started
+	m.access.Unlock()
+	if started {
+		return common.Close(provider)
+	}
+	return nil
+}
+
+func (m *Manager) Create(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, providerType string, options any) error {
+	if tag == "" {
+		return os.ErrInvalid
+	}
+
+	provider, err := m.registry.CreateProvider(ctx, router, logFactory, tag, providerType, options)
+	if err != nil {
+		return err
+	}
+	m.access.Lock()
+	defer m.access.Unlock()
+	if m.started {
+		for _, stage := range adapter.ListStartStages {
+			err = adapter.LegacyStart(provider, stage)
+			if err != nil {
+				return E.Cause(err, stage, " provider/", provider.Type(), "[", provider.Tag(), "]")
+			}
+		}
+	}
+	if existsProvider, loaded := m.providerByTag[tag]; loaded {
+		if m.started {
+			err = common.Close(existsProvider)
+			if err != nil {
+				return E.Cause(err, "close provider", provider.Type(), "[", existsProvider.Tag(), "]")
+			}
+		}
+		existsIndex := common.Index(m.providers, func(it adapter.Provider) bool {
+			return it == existsProvider
+		})
+		if existsIndex == -1 {
+			panic("invalid provider index")
+		}
+		m.providers = append(m.providers[:existsIndex], m.providers[existsIndex+1:]...)
+	}
+	m.providers = append(m.providers, provider)
+	m.providerByTag[tag] = provider
+	return nil
+}

--- a/adapter/provider/registry.go
+++ b/adapter/provider/registry.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+)
+
+type ConstructorFunc[T any] func(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options T) (adapter.Provider, error)
+
+func Register[Options any](registry *Registry, providerType string, constructor ConstructorFunc[Options]) {
+	registry.register(providerType, func() any {
+		return new(Options)
+	}, func(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, rawOptions any) (adapter.Provider, error) {
+		var options *Options
+		if rawOptions != nil {
+			options = rawOptions.(*Options)
+		}
+		return constructor(ctx, router, logFactory, tag, common.PtrValueOrDefault(options))
+	})
+}
+
+var _ adapter.ProviderRegistry = (*Registry)(nil)
+
+type (
+	optionsConstructorFunc func() any
+	constructorFunc        func(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options any) (adapter.Provider, error)
+)
+
+type Registry struct {
+	access       sync.Mutex
+	optionsType  map[string]optionsConstructorFunc
+	constructors map[string]constructorFunc
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		optionsType:  make(map[string]optionsConstructorFunc),
+		constructors: make(map[string]constructorFunc),
+	}
+}
+
+func (r *Registry) CreateOptions(providerType string) (any, bool) {
+	r.access.Lock()
+	defer r.access.Unlock()
+	optionsConstructor, loaded := r.optionsType[providerType]
+	if !loaded {
+		return nil, false
+	}
+	return optionsConstructor(), true
+}
+
+func (r *Registry) CreateProvider(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, providerType string, options any) (adapter.Provider, error) {
+	r.access.Lock()
+	defer r.access.Unlock()
+	constructor, loaded := r.constructors[providerType]
+	if !loaded {
+		return nil, E.New("provider type not found: '" + providerType + "'")
+	}
+	return constructor(ctx, router, logFactory, tag, options)
+}
+
+func (r *Registry) register(providerType string, optionsConstructor optionsConstructorFunc, constructor constructorFunc) {
+	r.access.Lock()
+	defer r.access.Unlock()
+	r.optionsType[providerType] = optionsConstructor
+	r.constructors[providerType] = constructor
+}

--- a/box.go
+++ b/box.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/adapter/provider"
 	boxService "github.com/sagernet/sing-box/adapter/service"
 	"github.com/sagernet/sing-box/common/certificate"
 	"github.com/sagernet/sing-box/common/dialer"
@@ -45,6 +46,7 @@ type Box struct {
 	endpoint        *endpoint.Manager
 	inbound         *inbound.Manager
 	outbound        *outbound.Manager
+	provider        *provider.Manager
 	service         *boxService.Manager
 	dnsTransport    *dns.TransportManager
 	dnsRouter       *dns.Router
@@ -63,6 +65,7 @@ type Options struct {
 func Context(
 	ctx context.Context,
 	inboundRegistry adapter.InboundRegistry,
+	providerRegistry adapter.ProviderRegistry,
 	outboundRegistry adapter.OutboundRegistry,
 	endpointRegistry adapter.EndpointRegistry,
 	dnsTransportRegistry adapter.DNSTransportRegistry,
@@ -72,6 +75,11 @@ func Context(
 		service.FromContext[adapter.InboundRegistry](ctx) == nil {
 		ctx = service.ContextWith[option.InboundOptionsRegistry](ctx, inboundRegistry)
 		ctx = service.ContextWith[adapter.InboundRegistry](ctx, inboundRegistry)
+	}
+	if service.FromContext[option.ProviderOptionsRegistry](ctx) == nil ||
+		service.FromContext[adapter.ProviderRegistry](ctx) == nil {
+		ctx = service.ContextWith[option.ProviderOptionsRegistry](ctx, providerRegistry)
+		ctx = service.ContextWith[adapter.ProviderRegistry](ctx, providerRegistry)
 	}
 	if service.FromContext[option.OutboundOptionsRegistry](ctx) == nil ||
 		service.FromContext[adapter.OutboundRegistry](ctx) == nil {
@@ -105,6 +113,7 @@ func New(options Options) (*Box, error) {
 	endpointRegistry := service.FromContext[adapter.EndpointRegistry](ctx)
 	inboundRegistry := service.FromContext[adapter.InboundRegistry](ctx)
 	outboundRegistry := service.FromContext[adapter.OutboundRegistry](ctx)
+	providerRegistry := service.FromContext[adapter.ProviderRegistry](ctx)
 	dnsTransportRegistry := service.FromContext[adapter.DNSTransportRegistry](ctx)
 	serviceRegistry := service.FromContext[adapter.ServiceRegistry](ctx)
 
@@ -116,6 +125,9 @@ func New(options Options) (*Box, error) {
 	}
 	if outboundRegistry == nil {
 		return nil, E.New("missing outbound registry in context")
+	}
+	if providerRegistry == nil {
+		return nil, E.New("missing provider registry in context")
 	}
 	if dnsTransportRegistry == nil {
 		return nil, E.New("missing DNS transport registry in context")
@@ -181,11 +193,13 @@ func New(options Options) (*Box, error) {
 	endpointManager := endpoint.NewManager(logFactory.NewLogger("endpoint"), endpointRegistry)
 	inboundManager := inbound.NewManager(logFactory.NewLogger("inbound"), inboundRegistry, endpointManager)
 	outboundManager := outbound.NewManager(logFactory.NewLogger("outbound"), outboundRegistry, endpointManager, routeOptions.Final)
+	providerManager := provider.NewManager(logFactory.NewLogger("provider"), providerRegistry)
 	dnsTransportManager := dns.NewTransportManager(logFactory.NewLogger("dns/transport"), dnsTransportRegistry, outboundManager, dnsOptions.Final)
 	serviceManager := boxService.NewManager(logFactory.NewLogger("service"), serviceRegistry)
 	service.MustRegister[adapter.EndpointManager](ctx, endpointManager)
 	service.MustRegister[adapter.InboundManager](ctx, inboundManager)
 	service.MustRegister[adapter.OutboundManager](ctx, outboundManager)
+	service.MustRegister[adapter.ProviderManager](ctx, providerManager)
 	service.MustRegister[adapter.DNSTransportManager](ctx, dnsTransportManager)
 	service.MustRegister[adapter.ServiceManager](ctx, serviceManager)
 	dnsRouter := dns.NewRouter(ctx, logFactory, dnsOptions)
@@ -276,6 +290,10 @@ func New(options Options) (*Box, error) {
 			return nil, E.Cause(err, "initialize inbound[", i, "]")
 		}
 	}
+	options.Outbounds = append(options.Outbounds, option.Outbound{
+		Tag:  "Compatible",
+		Type: C.TypeDirect,
+	})
 	for i, outboundOptions := range options.Outbounds {
 		var tag string
 		if outboundOptions.Tag != "" {
@@ -300,6 +318,25 @@ func New(options Options) (*Box, error) {
 		)
 		if err != nil {
 			return nil, E.Cause(err, "initialize outbound[", i, "]")
+		}
+	}
+	for i, providerOptions := range options.Providers {
+		var tag string
+		if providerOptions.Tag != "" {
+			tag = providerOptions.Tag
+		} else {
+			tag = F.ToString(i)
+		}
+		err = providerManager.Create(
+			ctx,
+			router,
+			logFactory,
+			tag,
+			providerOptions.Type,
+			providerOptions.Options,
+		)
+		if err != nil {
+			return nil, E.Cause(err, "initialize provider[", i, "]")
 		}
 	}
 	for i, serviceOptions := range options.Services {
@@ -391,6 +428,7 @@ func New(options Options) (*Box, error) {
 		endpoint:        endpointManager,
 		inbound:         inboundManager,
 		outbound:        outboundManager,
+		provider:        providerManager,
 		dnsTransport:    dnsTransportManager,
 		service:         serviceManager,
 		dnsRouter:       dnsRouter,
@@ -454,11 +492,11 @@ func (s *Box) preStart() error {
 	if err != nil {
 		return err
 	}
-	err = adapter.Start(s.logger, adapter.StartStateInitialize, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.outbound, s.inbound, s.endpoint, s.service)
+	err = adapter.Start(s.logger, adapter.StartStateInitialize, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.outbound, s.provider, s.inbound, s.endpoint, s.service)
 	if err != nil {
 		return err
 	}
-	err = adapter.Start(s.logger, adapter.StartStateStart, s.outbound, s.dnsTransport, s.dnsRouter, s.network, s.connection, s.router)
+	err = adapter.Start(s.logger, adapter.StartStateStart, s.outbound, s.provider, s.dnsTransport, s.dnsRouter, s.network, s.connection, s.router)
 	if err != nil {
 		return err
 	}
@@ -478,7 +516,7 @@ func (s *Box) start() error {
 	if err != nil {
 		return err
 	}
-	err = adapter.Start(s.logger, adapter.StartStatePostStart, s.outbound, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.inbound, s.endpoint, s.service)
+	err = adapter.Start(s.logger, adapter.StartStatePostStart, s.outbound, s.provider, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.inbound, s.endpoint, s.service)
 	if err != nil {
 		return err
 	}
@@ -486,7 +524,7 @@ func (s *Box) start() error {
 	if err != nil {
 		return err
 	}
-	err = adapter.Start(s.logger, adapter.StartStateStarted, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.outbound, s.inbound, s.endpoint, s.service)
+	err = adapter.Start(s.logger, adapter.StartStateStarted, s.network, s.dnsTransport, s.dnsRouter, s.connection, s.router, s.outbound, s.provider, s.inbound, s.endpoint, s.service)
 	if err != nil {
 		return err
 	}
@@ -512,6 +550,7 @@ func (s *Box) Close() error {
 		{"service", s.service},
 		{"endpoint", s.endpoint},
 		{"inbound", s.inbound},
+		{"provider", s.provider},
 		{"outbound", s.outbound},
 		{"router", s.router},
 		{"connection", s.connection},

--- a/cmd/sing-box/cmd_run.go
+++ b/cmd/sing-box/cmd_run.go
@@ -12,10 +12,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sagernet/sing-box"
+	box "github.com/sagernet/sing-box"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/provider/parser"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/common/json/badjson"
@@ -142,6 +143,14 @@ func create() (*box.Box, context.CancelFunc, error) {
 		cancel()
 		return nil, nil, E.Cause(err, "create service")
 	}
+
+	// PERF: Костыльно, хотелось бы переделать.
+	// Устанавливает этот логгер как стандартный.
+	// В cmd_run.go небыло вызова log.SetStdLogger() после создания box.
+	// В отличие от daemon/instance.go, здесь логгер из конфига не устанавливается
+	// как стандартный.
+	log.SetStdLogger(instance.LogFactory().Logger())
+	parser.SetLogger(instance.LogFactory().NewLogger("parser"))
 
 	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)

--- a/common/interrupt/context.go
+++ b/common/interrupt/context.go
@@ -11,3 +11,13 @@ func ContextWithIsExternalConnection(ctx context.Context) context.Context {
 func IsExternalConnectionFromContext(ctx context.Context) bool {
 	return ctx.Value(contextKeyIsExternalConnection{}) != nil
 }
+
+type contextKeyIsProviderConnection struct{}
+
+func ContextWithIsProviderConnection(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyIsProviderConnection{}, true)
+}
+
+func IsProviderConnectionFromContext(ctx context.Context) bool {
+	return ctx.Value(contextKeyIsProviderConnection{}) != nil
+}

--- a/common/interrupt/group.go
+++ b/common/interrupt/group.go
@@ -17,30 +17,31 @@ type Group struct {
 type groupConnItem struct {
 	conn       io.Closer
 	isExternal bool
+	isProvider bool
 }
 
 func NewGroup() *Group {
 	return &Group{}
 }
 
-func (g *Group) NewConn(conn net.Conn, isExternal bool) net.Conn {
+func (g *Group) NewConn(conn net.Conn, isExternal, isProvider bool) net.Conn {
 	g.access.Lock()
 	defer g.access.Unlock()
-	item := g.connections.PushBack(&groupConnItem{conn, isExternal})
+	item := g.connections.PushBack(&groupConnItem{conn, isExternal, isProvider})
 	return &Conn{Conn: conn, group: g, element: item}
 }
 
-func (g *Group) NewPacketConn(conn net.PacketConn, isExternal bool) net.PacketConn {
+func (g *Group) NewPacketConn(conn net.PacketConn, isExternal, isProvider bool) net.PacketConn {
 	g.access.Lock()
 	defer g.access.Unlock()
-	item := g.connections.PushBack(&groupConnItem{conn, isExternal})
+	item := g.connections.PushBack(&groupConnItem{conn, isExternal, isProvider})
 	return &PacketConn{PacketConn: conn, group: g, element: item}
 }
 
-func (g *Group) NewSingPacketConn(conn N.PacketConn, isExternal bool) N.PacketConn {
+func (g *Group) NewSingPacketConn(conn N.PacketConn, isExternal bool, isProvider bool) N.PacketConn {
 	g.access.Lock()
 	defer g.access.Unlock()
-	item := g.connections.PushBack(&groupConnItem{conn, isExternal})
+	item := g.connections.PushBack(&groupConnItem{conn, isExternal, isProvider})
 	return &SingPacketConn{PacketConn: conn, group: g, element: item}
 }
 
@@ -49,7 +50,7 @@ func (g *Group) Interrupt(interruptExternalConnections bool) {
 	defer g.access.Unlock()
 	var toDelete []*list.Element[*groupConnItem]
 	for element := g.connections.Front(); element != nil; element = element.Next() {
-		if !element.Value.isExternal || interruptExternalConnections {
+		if !element.Value.isProvider && !element.Value.isExternal || interruptExternalConnections {
 			element.Value.conn.Close()
 			toDelete = append(toDelete, element)
 		}

--- a/constant/provider.go
+++ b/constant/provider.go
@@ -1,0 +1,20 @@
+package constant
+
+const (
+	ProviderTypeInline = "inline"
+	ProviderTypeLocal  = "local"
+	ProviderTypeRemote = "remote"
+)
+
+func ProviderDisplayName(providerType string) string {
+	switch providerType {
+	case ProviderTypeInline:
+		return "Inline"
+	case ProviderTypeLocal:
+		return "Local"
+	case ProviderTypeRemote:
+		return "Remote"
+	default:
+		return "Unknown"
+	}
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -13,6 +13,7 @@ sing-box uses JSON for configuration files.
   "endpoints": [],
   "inbounds": [],
   "outbounds": [],
+  "providers": [],
   "route": {},
   "services": [],
   "experimental": {}
@@ -30,6 +31,7 @@ sing-box uses JSON for configuration files.
 | `endpoints`    | [Endpoint](./endpoint/)         |
 | `inbounds`     | [Inbound](./inbound/)           |
 | `outbounds`    | [Outbound](./outbound/)         |
+| `providers`    | [Provider](./provider/)         |
 | `route`        | [Route](./route/)               |
 | `services`     | [Service](./service/)           |
 | `experimental` | [Experimental](./experimental/) |

--- a/docs/configuration/index.zh.md
+++ b/docs/configuration/index.zh.md
@@ -13,6 +13,7 @@ sing-box 使用 JSON 作为配置文件格式。
   "endpoints": [],
   "inbounds": [],
   "outbounds": [],
+  "providers": [],
   "route": {},
   "services": [],
   "experimental": {}
@@ -30,6 +31,7 @@ sing-box 使用 JSON 作为配置文件格式。
 | `endpoints`    | [端点](./endpoint/)      |
 | `inbounds`     | [入站](./inbound/)       |
 | `outbounds`    | [出站](./outbound/)      |
+| `providers`    | [提供者](./provider/)         |
 | `route`        | [路由](./route/)         |
 | `services`     | [服务](./service/)       |
 | `experimental` | [实验性](./experimental/) |

--- a/docs/configuration/outbound/selector.md
+++ b/docs/configuration/outbound/selector.md
@@ -10,7 +10,14 @@
     "proxy-b",
     "proxy-c"
   ],
+  "providers": [
+    "provider-a",
+    "provider-b",
+  ],
+  "exclude": "",
+  "include": "",
   "default": "proxy-c",
+  "use_all_providers": false,
   "interrupt_exist_connections": false
 }
 ```
@@ -23,13 +30,31 @@
 
 #### outbounds
 
-==Required==
-
 List of outbound tags to select.
+
+#### providers
+
+List of [Provider](/configuration/provider) tags to select.
+
+#### use_all_providers
+
+Use all [Provider](/configuration/provider) to fill `outbounds`.
+
+#### exclude
+
+Exclude regular expression to filter `providers` nodes. The priority of the exclude expression is higher than the include expression.
+
+#### include
+
+Include regular expression to filter `providers` nodes.
 
 #### default
 
 The default outbound tag. The first outbound will be used if empty.
+
+#### use_all_providers
+
+Whether to use all providers for testing. `false` will be used if empty.
 
 #### interrupt_exist_connections
 

--- a/docs/configuration/outbound/selector.zh.md
+++ b/docs/configuration/outbound/selector.zh.md
@@ -10,7 +10,14 @@
     "proxy-b",
     "proxy-c"
   ],
+  "providers": [
+    "provider-a",
+    "provider-b",
+  ],
+  "exclude": "",
+  "include": "",
   "default": "proxy-c",
+  "use_all_providers": false,
   "interrupt_exist_connections": false
 }
 ```
@@ -23,13 +30,27 @@
 
 #### outbounds
 
-==必填==
-
 用于选择的出站标签列表。
+
+#### providers
+
+用于选择的[订阅](/zh/configuration/provider)标签列表。
+
+#### exclude
+
+排除 `providers` 节点的正则表达式。
+
+#### include
+
+包含 `providers` 节点的正则表达式。
 
 #### default
 
 默认的出站标签。默认使用第一个出站。
+
+#### use_all_providers
+
+是否使用所有提供者。默认使用 `false`。
 
 #### interrupt_exist_connections
 

--- a/docs/configuration/outbound/urltest.md
+++ b/docs/configuration/outbound/urltest.md
@@ -10,10 +10,17 @@
     "proxy-b",
     "proxy-c"
   ],
+  "providers": [
+    "provider-a",
+    "provider-b",
+  ],
+  "exclude": "",
+  "include": "",
   "url": "",
   "interval": "",
-  "tolerance": 0,
+  "tolerance": 50,
   "idle_timeout": "",
+  "use_all_providers": false,
   "interrupt_exist_connections": false
 }
 ```
@@ -22,9 +29,19 @@
 
 #### outbounds
 
-==Required==
-
 List of outbound tags to test.
+
+#### providers
+
+List of [Provider](/configuration/provider) tags to test.
+
+#### exclude
+
+Exclude regular expression to filter `providers` nodes.
+
+#### include
+
+Include regular expression to filter `providers` nodes.
 
 #### url
 
@@ -42,8 +59,13 @@ The test tolerance in milliseconds. `50` will be used if empty.
 
 The idle timeout. `30m` will be used if empty.
 
+#### use_all_providers
+
+Whether to use all providers for testing. `false` will be used if empty.
+
 #### interrupt_exist_connections
 
 Interrupt existing connections when the selected outbound has changed.
 
 Only inbound connections are affected by this setting, internal connections will always be interrupted.
+

--- a/docs/configuration/outbound/urltest.zh.md
+++ b/docs/configuration/outbound/urltest.zh.md
@@ -10,10 +10,17 @@
     "proxy-b",
     "proxy-c"
   ],
+  "providers": [
+    "provider-a",
+    "provider-b",
+  ],
+  "exclude": "",
+  "include": "",
   "url": "",
   "interval": "",
   "tolerance": 50,
   "idle_timeout": "",
+  "use_all_providers": false,
   "interrupt_exist_connections": false
 }
 ```
@@ -22,9 +29,19 @@
 
 #### outbounds
 
-==必填==
-
 用于测试的出站标签列表。
+
+#### providers
+
+用于测试的[订阅](/zh/configuration/provider)标签列表。
+
+#### exclude
+
+排除 `providers` 节点的正则表达式。
+
+#### include
+
+包含 `providers` 节点的正则表达式。
 
 #### url
 
@@ -41,6 +58,10 @@
 #### idle_timeout
 
 空闲超时。默认使用 `30m`。
+
+#### use_all_providers
+
+是否使用所有提供者。默认使用 `false`。
 
 #### interrupt_exist_connections
 

--- a/docs/configuration/provider/index.md
+++ b/docs/configuration/provider/index.md
@@ -1,0 +1,130 @@
+# Provider
+
+### Structure
+
+List of subscription providers.
+
+=== "Local File"
+
+    ```json
+    {
+      "providers": [
+        {
+          "type": "local",
+          "tag": "provider",
+          "path": "provider.txt",
+          "health_check": {
+            "enabled": false,
+            "url": "",
+            "interval": "",
+            "timeout": "",
+          }
+        }
+      ]
+    }
+    ```
+
+=== "Remote File"
+
+    ```json
+    {
+      "providers": [
+        {
+          "type": "remote",
+          "tag": "provider",
+          "health_check": {
+            "enabled": false,
+            "url": "",
+            "interval": "",
+            "timeout": "",
+          },
+          "url": "",
+          "exclude": "",
+          "include": "",
+          "user_agent": "",
+          "download_detour": "",
+          "update_interval": ""
+        }
+      ]
+    }
+    ```
+
+### Fields
+
+#### type
+
+==Required==
+
+Type of the provider. `local` or `remote`.
+
+#### tag
+
+==Required==
+
+Tag of the provider.
+
+The node `node_name` from `provider` will be tagged as `provider/node_name`.
+
+### Local or Remote Fields
+
+#### health_check
+
+Health check configuration.
+
+##### health_check.enabled
+
+Health check enabled.
+
+##### health_check.url
+
+Health check URL.
+
+##### health_check.interval
+
+Health check interval. The minimum value is `1m`, the default value is `10m`.
+
+##### health_check.timeout
+
+Health check timeout. the default value is `3s`.
+
+### Local Fields
+
+#### path
+
+==Required==
+
+!!! note ""
+
+    Will be automatically reloaded if file modified since sing-box 1.10.0.
+
+Local file path.
+
+### Remote Fields
+
+#### url
+
+==Required==
+
+URL to the provider.
+
+#### exclude
+
+Exclude regular expression to filter nodes.
+
+#### include
+
+Include regular expression to filter nodes.
+
+#### user_agent
+
+User agent used to download the provider.
+
+#### download_detour
+
+The tag of the outbound used to download from the provider.
+
+Default outbound will be used if empty.
+
+#### update_interval
+
+Update interval. The minimum value is `1m`, the default value is `24h`.

--- a/docs/configuration/provider/index.zh.md
+++ b/docs/configuration/provider/index.zh.md
@@ -1,0 +1,130 @@
+# 订阅
+
+### 结构
+
+订阅源列表。
+
+=== "本地文件"
+
+    ```json
+    {
+      "providers": [
+        {
+          "type": "local",
+          "tag": "provider",
+          "path": "provider.txt",
+          "health_check": {
+            "enabled": false,
+            "url": "",
+            "interval": "",
+            "timeout": "",
+          }
+        }
+      ]
+    }
+    ```
+
+=== "远程文件"
+
+    ```json
+    {
+      "providers": [
+        {
+          "type": "remote",
+          "tag": "provider",
+          "health_check": {
+            "enabled": false,
+            "url": "",
+            "interval": "",
+            "timeout": "",
+          },
+          "url": "",
+          "exclude": "",
+          "include": "",
+          "user_agent": "",
+          "download_detour": "",
+          "update_interval": ""
+        }
+      ]
+    }
+    ```
+
+### 字段
+
+#### type
+
+==必填==
+
+订阅源的类型。`local` 或 `remote`。
+
+#### tag
+
+==必填==
+
+订阅源的标签。
+
+来自 `provider` 的节点 `node_name`，导入后的标签为 `provider/node_name`。
+
+### 本地或远程字段
+
+#### health_check
+
+健康检查配置。
+
+##### health_check.enabled
+
+是否启用健康检查。
+
+##### health_check.url
+
+健康检查的 URL。
+
+##### health_check.interval
+
+健康检查的时间间隔。最小为 `1m`，默认为 `10m`。
+
+##### health_check.timeout
+
+健康检查的超时时间。默认为 `3s`。
+
+### 本地字段
+
+#### path
+
+==必填==
+
+!!! note ""
+
+    自 sing-box 1.10.0 起， 文件更改将自动重新加载。
+
+本地文件路径。
+
+### 远程字段
+
+#### url
+
+==必填==
+
+订阅源的 URL。
+
+#### exclude
+
+排除节点的正则表达式。
+
+#### include
+
+包含节点的正则表达式。
+
+#### user_agent
+
+用于下载订阅内容的 User-Agent。
+
+#### download_detour
+
+用于下载订阅内容的出站的标签。
+
+如果为空，将使用默认出站。
+
+#### update_interval
+
+更新订阅的时间间隔。最小为 `1m`，默认为 `24h`。

--- a/experimental/cachefile/cache.go
+++ b/experimental/cachefile/cache.go
@@ -398,3 +398,36 @@ func (c *CacheFile) SaveWARPConfig(tag string, set *adapter.SavedBinary) error {
 		return bucket.Put([]byte(tag), configBinary)
 	})
 }
+
+func (c *CacheFile) LoadSubscription(tag string) *adapter.SavedBinary {
+	var savedSet adapter.SavedBinary
+	err := c.DB.View(func(t *bbolt.Tx) error {
+		bucket := c.bucket(t, bucketRuleSet)
+		if bucket == nil {
+			return os.ErrNotExist
+		}
+		setBinary := bucket.Get([]byte(tag))
+		if len(setBinary) == 0 {
+			return os.ErrInvalid
+		}
+		return savedSet.UnmarshalBinary(setBinary)
+	})
+	if err != nil {
+		return nil
+	}
+	return &savedSet
+}
+
+func (c *CacheFile) SaveSubscription(tag string, sub *adapter.SavedBinary) error {
+	return c.DB.Batch(func(t *bbolt.Tx) error {
+		bucket, err := c.createBucket(t, bucketRuleSet)
+		if err != nil {
+			return err
+		}
+		setBinary, err := sub.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(tag), setBinary)
+	})
+}

--- a/experimental/clashapi/provider.go
+++ b/experimental/clashapi/provider.go
@@ -4,48 +4,78 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing/common/json/badjson"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
 
-func proxyProviderRouter() http.Handler {
+func proxyProviderRouter(server *Server) http.Handler {
 	r := chi.NewRouter()
-	r.Get("/", getProviders)
+	r.Get("/", getProviders(server))
 
 	r.Route("/{name}", func(r chi.Router) {
-		r.Use(parseProviderName, findProviderByName)
-		r.Get("/", getProvider)
+		r.Use(parseProviderName, findProviderByName(server))
+		r.Get("/", getProvider(server))
 		r.Put("/", updateProvider)
 		r.Get("/healthcheck", healthCheckProvider)
 	})
 	return r
 }
 
-func getProviders(w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, r, render.M{
-		"providers": render.M{},
-	})
+func getProviders(server *Server) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		providerMap := make(render.M)
+		for _, provider := range server.provider.Providers() {
+			providerMap[provider.Tag()] = providerInfo(server, provider)
+		}
+		render.JSON(w, r, render.M{
+			"providers": providerMap,
+		})
+	}
 }
 
-func getProvider(w http.ResponseWriter, r *http.Request) {
-	/*provider := r.Context().Value(CtxKeyProvider).(provider.ProxyProvider)
-	render.JSON(w, r, provider)*/
-	render.NoContent(w, r)
+func getProvider(server *Server) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provider := r.Context().Value(CtxKeyProvider).(adapter.Provider)
+		render.JSON(w, r, providerInfo(server, provider))
+	}
+}
+
+func providerInfo(server *Server, p adapter.Provider) *badjson.JSONObject {
+	var info badjson.JSONObject
+	proxies := make([]*badjson.JSONObject, 0)
+	for _, detour := range p.Outbounds() {
+		proxies = append(proxies, proxyInfo(server, detour))
+	}
+	info.Put("type", "Proxy")                                // Proxy, Rule
+	info.Put("vehicleType", C.ProviderDisplayName(p.Type())) // HTTP, File, Compatible
+	info.Put("name", p.Tag())
+	info.Put("proxies", proxies)
+	info.Put("updatedAt", p.UpdatedAt())
+	if p, ok := p.(adapter.ProviderSubscriptionInfo); ok {
+		info.Put("subscriptionInfo", p.SubscriptionInfo())
+	}
+	return &info
 }
 
 func updateProvider(w http.ResponseWriter, r *http.Request) {
-	/*provider := r.Context().Value(CtxKeyProvider).(provider.ProxyProvider)
-	if err := provider.Update(); err != nil {
-		render.Status(r, http.StatusServiceUnavailable)
-		render.JSON(w, r, newError(err.Error()))
-		return
-	}*/
+	provider := r.Context().Value(CtxKeyProvider).(adapter.Provider)
+	if provider, isUpdater := provider.(adapter.ProviderUpdater); isUpdater {
+		if err := provider.Update(); err != nil {
+			render.Status(r, http.StatusServiceUnavailable)
+			render.JSON(w, r, newError(err.Error()))
+			return
+		}
+	}
 	render.NoContent(w, r)
 }
 
 func healthCheckProvider(w http.ResponseWriter, r *http.Request) {
-	/*provider := r.Context().Value(CtxKeyProvider).(provider.ProxyProvider)
-	provider.HealthCheck()*/
+	provider := r.Context().Value(CtxKeyProvider).(adapter.Provider)
+	provider.HealthCheck(r.Context())
 	render.NoContent(w, r)
 }
 
@@ -57,18 +87,19 @@ func parseProviderName(next http.Handler) http.Handler {
 	})
 }
 
-func findProviderByName(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		/*name := r.Context().Value(CtxKeyProviderName).(string)
-		providers := tunnel.ProxyProviders()
-		provider, exist := providers[name]
-		if !exist {*/
-		render.Status(r, http.StatusNotFound)
-		render.JSON(w, r, ErrNotFound)
-		//return
-		//}
+func findProviderByName(server *Server) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			name := r.Context().Value(CtxKeyProviderName).(string)
+			provider, exist := server.provider.Get(name)
+			if !exist {
+				render.Status(r, http.StatusNotFound)
+				render.JSON(w, r, ErrNotFound)
+				return
+			}
 
-		// ctx := context.WithValue(r.Context(), CtxKeyProvider, provider)
-		// next.ServeHTTP(w, r.WithContext(ctx))
-	})
+			ctx := context.WithValue(r.Context(), CtxKeyProvider, provider)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }

--- a/experimental/clashapi/server.go
+++ b/experimental/clashapi/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	router         adapter.Router
 	dnsRouter      adapter.DNSRouter
 	outbound       adapter.OutboundManager
+	provider       adapter.ProviderManager
 	endpoint       adapter.EndpointManager
 	logger         log.Logger
 	httpServer     *http.Server
@@ -70,6 +71,7 @@ func NewServer(ctx context.Context, logFactory log.ObservableFactory, options op
 		router:    service.FromContext[adapter.Router](ctx),
 		dnsRouter: service.FromContext[adapter.DNSRouter](ctx),
 		outbound:  service.FromContext[adapter.OutboundManager](ctx),
+		provider:  service.FromContext[adapter.ProviderManager](ctx),
 		endpoint:  service.FromContext[adapter.EndpointManager](ctx),
 		logger:    logFactory.NewLogger("clash-api"),
 		httpServer: &http.Server{
@@ -122,7 +124,7 @@ func NewServer(ctx context.Context, logFactory log.ObservableFactory, options op
 		r.Mount("/proxies", proxyRouter(s, s.router))
 		r.Mount("/rules", ruleRouter(s.router))
 		r.Mount("/connections", connectionRouter(s.ctx, s.router, trafficManager))
-		r.Mount("/providers/proxies", proxyProviderRouter())
+		r.Mount("/providers/proxies", proxyProviderRouter(s))
 		r.Mount("/providers/rules", ruleProviderRouter())
 		r.Mount("/script", scriptRouter())
 		r.Mount("/profile", profileRouter())

--- a/experimental/libbox/config.go
+++ b/experimental/libbox/config.go
@@ -33,7 +33,7 @@ func baseContext(platformInterface PlatformInterface) context.Context {
 	}
 	ctx := context.Background()
 	ctx = filemanager.WithDefault(ctx, sWorkingPath, sTempPath, sUserID, sGroupID)
-	return box.Context(ctx, include.InboundRegistry(), include.OutboundRegistry(), include.EndpointRegistry(), dnsRegistry, include.ServiceRegistry())
+	return box.Context(ctx, include.InboundRegistry(), include.ProviderRegistry(), include.OutboundRegistry(), include.EndpointRegistry(), dnsRegistry, include.ServiceRegistry())
 }
 
 func parseConfig(ctx context.Context, configContent string) (option.Options, error) {

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	howett.net/plist v1.0.1
 )
 
@@ -167,7 +168,6 @@ require (
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 

--- a/include/registry.go
+++ b/include/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/adapter/provider"
 	"github.com/sagernet/sing-box/adapter/service"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/dns"
@@ -36,13 +37,15 @@ import (
 	"github.com/sagernet/sing-box/protocol/tunnel"
 	"github.com/sagernet/sing-box/protocol/vless"
 	"github.com/sagernet/sing-box/protocol/vmess"
+	providerLocal "github.com/sagernet/sing-box/provider/local"
+	"github.com/sagernet/sing-box/provider/remote"
 	"github.com/sagernet/sing-box/service/resolved"
 	"github.com/sagernet/sing-box/service/ssmapi"
 	E "github.com/sagernet/sing/common/exceptions"
 )
 
 func Context(ctx context.Context) context.Context {
-	return box.Context(ctx, InboundRegistry(), OutboundRegistry(), EndpointRegistry(), DNSTransportRegistry(), ServiceRegistry())
+	return box.Context(ctx, InboundRegistry(), ProviderRegistry(), OutboundRegistry(), EndpointRegistry(), DNSTransportRegistry(), ServiceRegistry())
 }
 
 func InboundRegistry() *inbound.Registry {
@@ -67,6 +70,16 @@ func InboundRegistry() *inbound.Registry {
 
 	registerQUICInbounds(registry)
 	registerStubForRemovedInbounds(registry)
+
+	return registry
+}
+
+func ProviderRegistry() *provider.Registry {
+	registry := provider.NewRegistry()
+
+	providerLocal.RegisterProviderInline(registry)
+	providerLocal.RegisterProviderLocal(registry)
+	remote.RegisterProvider(registry)
 
 	return registry
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,8 @@ nav:
           - DNS: configuration/outbound/dns.md
           - Selector: configuration/outbound/selector.md
           - URLTest: configuration/outbound/urltest.md
+      - Provider:
+          - configuration/provider/index.md
       - Service:
           - configuration/service/index.md
           - DERP: configuration/service/derp.md
@@ -276,6 +278,7 @@ plugins:
             Endpoint: 端点
             Inbound: 入站
             Outbound: 出站
+            Provider: 提供者
 
             Manual: 手册
       reconfigure_material: true

--- a/option/group.go
+++ b/option/group.go
@@ -3,16 +3,24 @@ package option
 import "github.com/sagernet/sing/common/json/badoption"
 
 type SelectorOutboundOptions struct {
-	Outbounds                 []string `json:"outbounds"`
-	Default                   string   `json:"default,omitempty"`
-	InterruptExistConnections bool     `json:"interrupt_exist_connections,omitempty"`
+	GroupCommonOption
+	Default                   string `json:"default,omitempty"`
+	InterruptExistConnections bool   `json:"interrupt_exist_connections,omitempty"`
 }
 
 type URLTestOutboundOptions struct {
-	Outbounds                 []string           `json:"outbounds"`
+	GroupCommonOption
 	URL                       string             `json:"url,omitempty"`
 	Interval                  badoption.Duration `json:"interval,omitempty"`
 	Tolerance                 uint16             `json:"tolerance,omitempty"`
 	IdleTimeout               badoption.Duration `json:"idle_timeout,omitempty"`
 	InterruptExistConnections bool               `json:"interrupt_exist_connections,omitempty"`
+}
+
+type GroupCommonOption struct {
+	Outbounds       []string          `json:"outbounds"`
+	Providers       []string          `json:"providers"`
+	Exclude         *badoption.Regexp `json:"exclude,omitempty"`
+	Include         *badoption.Regexp `json:"include,omitempty"`
+	UseAllProviders bool              `json:"use_all_providers,omitempty"`
 }

--- a/option/options.go
+++ b/option/options.go
@@ -19,6 +19,7 @@ type _Options struct {
 	Endpoints    []Endpoint           `json:"endpoints,omitempty"`
 	Inbounds     []Inbound            `json:"inbounds,omitempty"`
 	Outbounds    []Outbound           `json:"outbounds,omitempty"`
+	Providers    []Provider           `json:"providers,omitempty"`
 	Route        *RouteOptions        `json:"route,omitempty"`
 	Services     []Service            `json:"services,omitempty"`
 	Experimental *ExperimentalOptions `json:"experimental,omitempty"`

--- a/option/provider.go
+++ b/option/provider.go
@@ -1,0 +1,75 @@
+package option
+
+import (
+	"context"
+
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/common/json/badjson"
+	"github.com/sagernet/sing/common/json/badoption"
+	"github.com/sagernet/sing/service"
+)
+
+type ProviderOptionsRegistry interface {
+	CreateOptions(providerType string) (any, bool)
+}
+type _Provider struct {
+	Type    string `json:"type"`
+	Tag     string `json:"tag,omitempty"`
+	Options any    `json:"-"`
+}
+
+type Provider _Provider
+
+func (h *Provider) MarshalJSONContext(ctx context.Context) ([]byte, error) {
+	return badjson.MarshallObjectsContext(ctx, (*_Provider)(h), h.Options)
+}
+
+func (h *Provider) UnmarshalJSONContext(ctx context.Context, content []byte) error {
+	err := json.UnmarshalContext(ctx, content, (*_Provider)(h))
+	if err != nil {
+		return err
+	}
+	registry := service.FromContext[ProviderOptionsRegistry](ctx)
+	if registry == nil {
+		return E.New("missing provider options registry in context")
+	}
+	options, loaded := registry.CreateOptions(h.Type)
+	if !loaded {
+		return E.New("unknown provider type: ", h.Type)
+	}
+	err = badjson.UnmarshallExcludedContext(ctx, content, (*_Provider)(h), options)
+	if err != nil {
+		return err
+	}
+	h.Options = options
+	return nil
+}
+
+type ProviderLocalOptions struct {
+	Path        string                     `json:"path"`
+	HealthCheck ProviderHealthCheckOptions `json:"health_check,omitempty"`
+}
+
+type ProviderRemoteOptions struct {
+	URL            string             `json:"url"`
+	UserAgent      string             `json:"user_agent,omitempty"`
+	DownloadDetour string             `json:"download_detour,omitempty"`
+	UpdateInterval badoption.Duration `json:"update_interval,omitempty"`
+
+	Exclude     *badoption.Regexp          `json:"exclude,omitempty"`
+	Include     *badoption.Regexp          `json:"include,omitempty"`
+	HealthCheck ProviderHealthCheckOptions `json:"health_check,omitempty"`
+}
+
+type ProviderInlineOptions struct {
+	Outbounds   []Outbound                 `json:"outbounds,omitempty"`
+	HealthCheck ProviderHealthCheckOptions `json:"health_check,omitempty"`
+}
+
+type ProviderHealthCheckOptions struct {
+	Enabled  bool               `json:"enabled,omitempty"`
+	URL      string             `json:"url,omitempty"`
+	Interval badoption.Duration `json:"interval,omitempty"`
+	Timeout  badoption.Duration `json:"timeout,omitempty"`
+}

--- a/protocol/group/selector.go
+++ b/protocol/group/selector.go
@@ -3,6 +3,7 @@ package group
 import (
 	"context"
 	"net"
+	"regexp"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -42,11 +43,20 @@ type Selector struct {
 	selected                     common.TypedValue[adapter.Outbound]
 	interruptGroup               *interrupt.Group
 	interruptExternalConnections bool
+
+	provider       adapter.ProviderManager
+	providers      map[string]adapter.Provider
+	outboundsCache map[string][]adapter.Outbound
+
+	providerTags    []string
+	exclude         *regexp.Regexp
+	include         *regexp.Regexp
+	useAllProviders bool
 }
 
 func NewSelector(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.SelectorOutboundOptions) (adapter.Outbound, error) {
 	outbound := &Selector{
-		Adapter:                      outbound.NewAdapter(C.TypeSelector, tag, nil, options.Outbounds),
+		Adapter:                      outbound.NewAdapter(C.TypeSelector, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.Outbounds),
 		ctx:                          ctx,
 		outbound:                     service.FromContext[adapter.OutboundManager](ctx),
 		connection:                   service.FromContext[adapter.ConnectionManager](ctx),
@@ -56,9 +66,15 @@ func NewSelector(ctx context.Context, router adapter.Router, logger log.ContextL
 		outbounds:                    make(map[string]adapter.Outbound),
 		interruptGroup:               interrupt.NewGroup(),
 		interruptExternalConnections: options.InterruptExistConnections,
-	}
-	if len(outbound.tags) == 0 {
-		return nil, E.New("missing tags")
+
+		provider:       service.FromContext[adapter.ProviderManager](ctx),
+		providers:      make(map[string]adapter.Provider),
+		outboundsCache: make(map[string][]adapter.Outbound),
+
+		providerTags:    options.Providers,
+		exclude:         (*regexp.Regexp)(options.Exclude),
+		include:         (*regexp.Regexp)(options.Include),
+		useAllProviders: options.UseAllProviders,
 	}
 	return outbound, nil
 }
@@ -72,6 +88,28 @@ func (s *Selector) Network() []string {
 }
 
 func (s *Selector) Start() error {
+	if s.useAllProviders {
+		var providerTags []string
+		for _, provider := range s.provider.Providers() {
+			providerTags = append(providerTags, provider.Tag())
+			s.providers[provider.Tag()] = provider
+			provider.RegisterCallback(s.onProviderUpdated)
+		}
+		s.providerTags = providerTags
+	} else {
+		for i, tag := range s.providerTags {
+			provider, loaded := s.provider.Get(tag)
+			if !loaded {
+				return E.New("outbound provider ", i, " not found: ", tag)
+			}
+			s.providers[tag] = provider
+			provider.RegisterCallback(s.onProviderUpdated)
+		}
+	}
+	if len(s.tags)+len(s.providerTags) == 0 {
+		return E.New("missing outbound and provider tags")
+	}
+
 	for i, tag := range s.tags {
 		detour, loaded := s.outbound.Outbound(tag)
 		if !loaded {
@@ -79,31 +117,16 @@ func (s *Selector) Start() error {
 		}
 		s.outbounds[tag] = detour
 	}
-
-	if s.Tag() != "" {
-		cacheFile := service.FromContext[adapter.CacheFile](s.ctx)
-		if cacheFile != nil {
-			selected := cacheFile.LoadSelected(s.Tag())
-			if selected != "" {
-				detour, loaded := s.outbounds[selected]
-				if loaded {
-					s.selected.Store(detour)
-					return nil
-				}
-			}
-		}
+	if len(s.tags) == 0 {
+		detour, _ := s.outbound.Outbound("Compatible")
+		s.tags = append(s.tags, detour.Tag())
+		s.outbounds[detour.Tag()] = detour
 	}
-
-	if s.defaultTag != "" {
-		detour, loaded := s.outbounds[s.defaultTag]
-		if !loaded {
-			return E.New("default outbound not found: ", s.defaultTag)
-		}
-		s.selected.Store(detour)
-		return nil
+	outbound, err := s.outboundSelect()
+	if err != nil {
+		return err
 	}
-
-	s.selected.Store(s.outbounds[s.tags[0]])
+	s.selected.Store(outbound)
 	return nil
 }
 
@@ -145,7 +168,7 @@ func (s *Selector) DialContext(ctx context.Context, network string, destination 
 	if err != nil {
 		return nil, err
 	}
-	return s.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+	return s.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx)), nil
 }
 
 func (s *Selector) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
@@ -153,13 +176,13 @@ func (s *Selector) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 	if err != nil {
 		return nil, err
 	}
-	return s.interruptGroup.NewPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+	return s.interruptGroup.NewPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx)), nil
 }
 
 func (s *Selector) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
 	selected := s.selected.Load()
-	conn = s.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx))
+	conn = s.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx))
 	if outboundHandler, isHandler := selected.(adapter.ConnectionHandlerEx); isHandler {
 		outboundHandler.NewConnectionEx(ctx, conn, metadata, onClose)
 	} else {
@@ -170,7 +193,7 @@ func (s *Selector) NewConnectionEx(ctx context.Context, conn net.Conn, metadata 
 func (s *Selector) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
 	selected := s.selected.Load()
-	conn = s.interruptGroup.NewSingPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx))
+	conn = s.interruptGroup.NewSingPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx))
 	if outboundHandler, isHandler := selected.(adapter.PacketConnectionHandlerEx); isHandler {
 		outboundHandler.NewPacketConnectionEx(ctx, conn, metadata, onClose)
 	} else {
@@ -191,4 +214,78 @@ func RealTag(detour adapter.Outbound) string {
 		return group.Now()
 	}
 	return detour.Tag()
+}
+
+func (s *Selector) onProviderUpdated(tag string) error {
+	_, loaded := s.providers[tag]
+	if !loaded {
+		return E.New(s.Tag(), ": ", "outbound provider not found: ", tag)
+	}
+	var (
+		tags          = s.Dependencies()
+		outboundByTag = make(map[string]adapter.Outbound)
+	)
+	for _, tag := range tags {
+		outboundByTag[tag] = s.outbounds[tag]
+	}
+	for _, providerTag := range s.providerTags {
+		if providerTag != tag && s.outboundsCache[providerTag] != nil {
+			for _, detour := range s.outboundsCache[providerTag] {
+				tags = append(tags, detour.Tag())
+				outboundByTag[detour.Tag()] = detour
+			}
+			continue
+		}
+		provider := s.providers[providerTag]
+		var cache []adapter.Outbound
+		for _, detour := range provider.Outbounds() {
+			tag := detour.Tag()
+			if s.exclude != nil && s.exclude.MatchString(tag) {
+				continue
+			}
+			if s.include != nil && !s.include.MatchString(tag) {
+				continue
+			}
+			tags = append(tags, tag)
+			cache = append(cache, detour)
+			outboundByTag[tag] = detour
+		}
+		s.outboundsCache[providerTag] = cache
+	}
+	if len(tags) == 0 {
+		detour, _ := s.outbound.Outbound("Compatible")
+		tags = append(tags, detour.Tag())
+		outboundByTag[detour.Tag()] = detour
+	}
+	s.tags, s.outbounds = tags, outboundByTag
+	detour, _ := s.outboundSelect()
+	if s.selected.Swap(detour) != detour {
+		s.interruptGroup.Interrupt(s.interruptExternalConnections)
+	}
+	return nil
+}
+
+func (s *Selector) outboundSelect() (adapter.Outbound, error) {
+	if s.Tag() != "" {
+		cacheFile := service.FromContext[adapter.CacheFile](s.ctx)
+		if cacheFile != nil {
+			selected := cacheFile.LoadSelected(s.Tag())
+			if selected != "" {
+				detour, loaded := s.outbounds[selected]
+				if loaded {
+					return detour, nil
+				}
+			}
+		}
+	}
+
+	if s.defaultTag != "" {
+		detour, loaded := s.outbounds[s.defaultTag]
+		if !loaded {
+			return nil, E.New("default outbound not found: ", s.defaultTag)
+		}
+		return detour, nil
+	}
+
+	return s.outbounds[s.tags[0]], nil
 }

--- a/protocol/group/urltest.go
+++ b/protocol/group/urltest.go
@@ -3,6 +3,7 @@ package group
 import (
 	"context"
 	"net"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,16 @@ type URLTest struct {
 	idleTimeout                  time.Duration
 	group                        *URLTestGroup
 	interruptExternalConnections bool
+
+	provider       adapter.ProviderManager
+	providers      map[string]adapter.Provider
+	outboundsCache map[string][]adapter.Outbound
+	cancel         context.CancelFunc
+
+	providerTags    []string
+	exclude         *regexp.Regexp
+	include         *regexp.Regexp
+	useAllProviders bool
 }
 
 func NewURLTest(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.URLTestOutboundOptions) (adapter.Outbound, error) {
@@ -61,20 +72,53 @@ func NewURLTest(ctx context.Context, router adapter.Router, logger log.ContextLo
 		tolerance:                    options.Tolerance,
 		idleTimeout:                  time.Duration(options.IdleTimeout),
 		interruptExternalConnections: options.InterruptExistConnections,
-	}
-	if len(outbound.tags) == 0 {
-		return nil, E.New("missing tags")
+
+		provider:       service.FromContext[adapter.ProviderManager](ctx),
+		providers:      make(map[string]adapter.Provider),
+		outboundsCache: make(map[string][]adapter.Outbound),
+
+		providerTags:    options.Providers,
+		exclude:         (*regexp.Regexp)(options.Exclude),
+		include:         (*regexp.Regexp)(options.Include),
+		useAllProviders: options.UseAllProviders,
 	}
 	return outbound, nil
 }
 
 func (s *URLTest) Start() error {
+	if s.useAllProviders {
+		var providerTags []string
+		for _, provider := range s.provider.Providers() {
+			providerTags = append(providerTags, provider.Tag())
+			s.providers[provider.Tag()] = provider
+			provider.RegisterCallback(s.onProviderUpdated)
+		}
+		s.providerTags = providerTags
+	} else {
+		for i, tag := range s.providerTags {
+			provider, loaded := s.provider.Get(tag)
+			if !loaded {
+				return E.New("outbound provider ", i, " not found: ", tag)
+			}
+			s.providers[tag] = provider
+			provider.RegisterCallback(s.onProviderUpdated)
+		}
+	}
+	if len(s.tags)+len(s.providerTags) == 0 {
+		return E.New("missing outbound and provider tags")
+	}
+
 	outbounds := make([]adapter.Outbound, 0, len(s.tags))
 	for i, tag := range s.tags {
 		detour, loaded := s.outbound.Outbound(tag)
 		if !loaded {
 			return E.New("outbound ", i, " not found: ", tag)
 		}
+		outbounds = append(outbounds, detour)
+	}
+	if len(s.tags) == 0 {
+		detour, _ := s.outbound.Outbound("Compatible")
+		s.tags = append(s.tags, detour.Tag())
 		outbounds = append(outbounds, detour)
 	}
 	group, err := NewURLTestGroup(s.ctx, s.outbound, s.logger, outbounds, s.link, s.interval, s.tolerance, s.idleTimeout, s.interruptExternalConnections)
@@ -136,7 +180,7 @@ func (s *URLTest) DialContext(ctx context.Context, network string, destination M
 	}
 	conn, err := outbound.DialContext(ctx, network, destination)
 	if err == nil {
-		return s.group.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+		return s.group.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx)), nil
 	}
 	s.logger.ErrorContext(ctx, err)
 	s.group.history.DeleteURLTestHistory(outbound.Tag())
@@ -154,7 +198,7 @@ func (s *URLTest) ListenPacket(ctx context.Context, destination M.Socksaddr) (ne
 	}
 	conn, err := outbound.ListenPacket(ctx, destination)
 	if err == nil {
-		return s.group.interruptGroup.NewPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+		return s.group.interruptGroup.NewPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx)), nil
 	}
 	s.logger.ErrorContext(ctx, err)
 	s.group.history.DeleteURLTestHistory(outbound.Tag())
@@ -163,13 +207,13 @@ func (s *URLTest) ListenPacket(ctx context.Context, destination M.Socksaddr) (ne
 
 func (s *URLTest) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
-	conn = s.group.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx))
+	conn = s.group.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx))
 	s.connection.NewConnection(ctx, s, conn, metadata, onClose)
 }
 
 func (s *URLTest) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	ctx = interrupt.ContextWithIsExternalConnection(ctx)
-	conn = s.group.interruptGroup.NewSingPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx))
+	conn = s.group.interruptGroup.NewSingPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx), interrupt.IsProviderConnectionFromContext(ctx))
 	s.connection.NewPacketConnection(ctx, s, conn, metadata, onClose)
 }
 
@@ -186,6 +230,63 @@ func (s *URLTest) NewDirectRouteConnection(metadata adapter.InboundContext, rout
 		return nil, E.New(metadata.Network, " is not supported by outbound: ", selected.Tag())
 	}
 	return selected.(adapter.DirectRouteOutbound).NewDirectRouteConnection(metadata, routeContext, timeout)
+}
+
+func (s *URLTest) onProviderUpdated(tag string) error {
+	_, loaded := s.providers[tag]
+	if !loaded {
+		return E.New("outbound provider not found: ", tag)
+	}
+	var (
+		tags      = s.Dependencies()
+		outbounds []adapter.Outbound
+	)
+	for _, tag := range tags {
+		detour, _ := s.outbound.Outbound(tag)
+		outbounds = append(outbounds, detour)
+	}
+	for _, providerTag := range s.providerTags {
+		if providerTag != tag && s.outboundsCache[providerTag] != nil {
+			for _, detour := range s.outboundsCache[providerTag] {
+				tags = append(tags, detour.Tag())
+				outbounds = append(outbounds, detour)
+			}
+			continue
+		}
+		provider := s.providers[providerTag]
+		var cache []adapter.Outbound
+		for _, detour := range provider.Outbounds() {
+			tag := detour.Tag()
+			if s.exclude != nil && s.exclude.MatchString(tag) {
+				continue
+			}
+			if s.include != nil && !s.include.MatchString(tag) {
+				continue
+			}
+			tags = append(tags, tag)
+			cache = append(cache, detour)
+		}
+		outbounds = append(outbounds, cache...)
+		s.outboundsCache[providerTag] = cache
+	}
+	if len(tags) == 0 {
+		detour, _ := s.outbound.Outbound("Compatible")
+		tags = append(tags, detour.Tag())
+		outbounds = append(outbounds, detour)
+	}
+	s.tags, s.group.outbounds = tags, outbounds
+	s.group.access.Lock()
+	if s.group.ticker != nil {
+		s.group.ticker.Reset(s.group.interval)
+	}
+	s.group.access.Unlock()
+	ctx, cancel := context.WithCancel(s.ctx)
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.cancel = cancel
+	s.URLTest(ctx)
+	return nil
 }
 
 type URLTestGroup struct {
@@ -407,7 +508,11 @@ func (g *URLTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 		})
 	}
 	b.Wait()
-	g.performUpdateCheck()
+	select {
+	case <-ctx.Done():
+	default:
+		g.performUpdateCheck()
+	}
 	return result, nil
 }
 

--- a/provider/local/lcoal.go
+++ b/provider/local/lcoal.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sagernet/fswatch"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/provider"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/provider/parser"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/filemanager"
+)
+
+func RegisterProviderLocal(registry *provider.Registry) {
+	provider.Register[option.ProviderLocalOptions](registry, C.ProviderTypeLocal, NewProviderLocal)
+}
+
+func RegisterProviderInline(registry *provider.Registry) {
+	provider.Register[option.ProviderInlineOptions](registry, C.ProviderTypeInline, NewProviderInline)
+}
+
+var _ adapter.Provider = (*ProviderLocal)(nil)
+
+type ProviderLocal struct {
+	provider.Adapter
+	ctx         context.Context
+	logger      log.ContextLogger
+	provider    adapter.ProviderManager
+	path        string
+	lastOutOpts []option.Outbound
+	lastUpdated time.Time
+	watcher     *fswatch.Watcher
+}
+
+func NewProviderInline(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options option.ProviderInlineOptions) (adapter.Provider, error) {
+	var (
+		outbound = service.FromContext[adapter.OutboundManager](ctx)
+		logger   = logFactory.NewLogger(F.ToString("provider/inline", "[", tag, "]"))
+	)
+	provider := &ProviderLocal{
+		Adapter: provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeInline, options.HealthCheck),
+		ctx:     ctx,
+		logger:  logger,
+	}
+	provider.UpdateOutbounds(nil, options.Outbounds)
+	return provider, nil
+}
+
+func NewProviderLocal(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options option.ProviderLocalOptions) (adapter.Provider, error) {
+	if options.Path == "" {
+		return nil, E.New("provider path is required")
+	}
+	var (
+		outbound = service.FromContext[adapter.OutboundManager](ctx)
+		logger   = logFactory.NewLogger(F.ToString("provider/local", "[", tag, "]"))
+	)
+	provider := &ProviderLocal{
+		Adapter:  provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeLocal, options.HealthCheck),
+		ctx:      ctx,
+		logger:   logger,
+		provider: service.FromContext[adapter.ProviderManager](ctx),
+	}
+	filePath := filemanager.BasePath(ctx, options.Path)
+	provider.path, _ = filepath.Abs(filePath)
+	watcher, err := fswatch.NewWatcher(fswatch.Options{
+		Path: []string{filePath},
+		Callback: func(path string) {
+			uErr := provider.reloadFile(path)
+			if uErr != nil {
+				logger.Error(E.Cause(uErr, "reload provider ", tag))
+			}
+			provider.UpdateGroups()
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	provider.watcher = watcher
+	return provider, nil
+}
+
+func (s *ProviderLocal) Start() error {
+	err := s.reloadFile(s.path)
+	if err != nil {
+		return err
+	}
+	s.UpdateGroups()
+	if s.watcher != nil {
+		err := s.watcher.Start()
+		if err != nil {
+			s.logger.Error(E.Cause(err, "watch provider file"))
+		}
+	}
+	return s.Adapter.Start()
+}
+
+func (s *ProviderLocal) UpdatedAt() time.Time {
+	return s.lastUpdated
+}
+
+func (s *ProviderLocal) reloadFile(path string) error {
+	if fileInfo, err := os.Stat(path); err == nil {
+		s.lastUpdated = fileInfo.ModTime()
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	outboundOpts, err := parser.ParseSubscription(s.ctx, string(content))
+	if err != nil {
+		return err
+	}
+	s.UpdateOutbounds(s.lastOutOpts, outboundOpts)
+	s.lastOutOpts = outboundOpts
+	return nil
+}
+
+func (s *ProviderLocal) Close() error {
+	return common.Close(&s.Adapter, common.PtrOrNil(s.watcher))
+}

--- a/provider/parser/clash.go
+++ b/provider/parser/clash.go
@@ -1,0 +1,843 @@
+package parser
+
+import (
+	"context"
+	"encoding/base64"
+	"strconv"
+	"strings"
+
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/byteformats"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/json/badoption"
+	N "github.com/sagernet/sing/common/network"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ClashConfig struct {
+	Proxies []ClashProxy `yaml:"proxies"`
+}
+
+type _ClashProxy struct {
+	Name    string `yaml:"name"`
+	Type    string `yaml:"type"`
+	Options Proxy  `yaml:"-"`
+
+	SingType string `yaml:"-"`
+}
+type ClashProxy _ClashProxy
+
+type Proxy interface {
+	Build() any
+}
+
+func (c *ClashProxy) UnmarshalYAML(value *yaml.Node) error {
+	err := value.Decode((*_ClashProxy)(c))
+	if err != nil {
+		return err
+	}
+	var options Proxy
+	switch c.Type {
+	case "ss":
+		c.SingType = C.TypeShadowsocks
+		options = &ShadowSocksOption{}
+	case "tuic":
+		c.SingType = C.TypeTUIC
+		options = &TuicOption{}
+	case "vmess":
+		c.SingType = C.TypeVMess
+		options = &VmessOption{}
+	case "vless":
+		c.SingType = C.TypeVLESS
+		options = &VlessOption{}
+	case "socks5":
+		c.SingType = C.TypeSOCKS
+		options = &Socks5Option{}
+	case "http":
+		c.SingType = C.TypeHTTP
+		options = &HttpOption{}
+	case "trojan":
+		c.SingType = C.TypeTrojan
+		options = &TrojanOption{}
+	case "hysteria":
+		c.SingType = C.TypeHysteria
+		options = &HysteriaOption{}
+	case "hysteria2":
+		c.SingType = C.TypeHysteria2
+		options = &Hysteria2Option{}
+	case "ssh":
+		c.SingType = C.TypeSSH
+		options = &SSHOption{}
+	case "anytls":
+		c.SingType = C.TypeAnyTLS
+		options = &AnyTLSOption{}
+	default:
+		return nil
+	}
+	err = value.Decode(options)
+	if err != nil {
+		return err
+	}
+	c.Options = options
+	return nil
+}
+
+func (c *ClashProxy) Build() option.Outbound {
+	outbound := option.Outbound{
+		Tag:  c.Name,
+		Type: c.SingType,
+	}
+	if c.Options != nil {
+		outbound.Options = c.Options.Build()
+	}
+	return outbound
+}
+
+func ParseClashSubscription(_ context.Context, content string) ([]option.Outbound, error) {
+	config := &ClashConfig{}
+	err := yaml.Unmarshal([]byte(content), &config)
+	if err != nil {
+		return nil, E.Cause(err, "parse clash config")
+	}
+	outbounds := common.FilterIsInstance(config.Proxies, func(proxy ClashProxy) (option.Outbound, bool) {
+		if proxy.SingType == "" {
+			return option.Outbound{}, false
+		}
+		return proxy.Build(), true
+	})
+	return outbounds, nil
+}
+
+type ShadowSocksOption struct {
+	DialerOptions     `yaml:",inline"`
+	ServerOptions     `yaml:",inline"`
+	Password          string         `yaml:"password"`
+	Cipher            string         `yaml:"cipher"`
+	UDP               bool           `yaml:"udp,omitempty"`
+	Plugin            string         `yaml:"plugin,omitempty"`
+	PluginOpts        map[string]any `yaml:"plugin-opts,omitempty"`
+	UDPOverTCP        bool           `yaml:"udp-over-tcp,omitempty"`
+	UDPOverTCPVersion int            `yaml:"udp-over-tcp-version,omitempty"`
+	MuxOpts           *MuxOptions    `yaml:"smux,omitempty"`
+}
+
+func (s *ShadowSocksOption) Build() any {
+	return &option.ShadowsocksOutboundOptions{
+		DialerOptions: s.DialerOptions.Build(),
+		ServerOptions: s.ServerOptions.Build(),
+		Password:      s.Password,
+		Method:        clashShadowsocksCipher(s.Cipher),
+		Plugin:        clashPluginName(s.Plugin),
+		PluginOptions: clashPluginOptions(s.Plugin, s.PluginOpts),
+		Network:       clashNetworks(s.UDP),
+		UDPOverTCP: &option.UDPOverTCPOptions{
+			Enabled: s.UDPOverTCP,
+			Version: uint8(s.UDPOverTCPVersion),
+		},
+		Multiplex: s.MuxOpts.Build(),
+	}
+}
+
+type TuicOption struct {
+	DialerOptions        `yaml:",inline"`
+	ServerOptions        `yaml:",inline"`
+	TLSOptions           `yaml:",inline"`
+	UUID                 string `yaml:"uuid,omitempty"`
+	Password             string `yaml:"password,omitempty"`
+	Ip                   string `yaml:"ip,omitempty"`
+	HeartbeatInterval    int    `yaml:"heartbeat-interval,omitempty"`
+	DisableSni           bool   `yaml:"disable-sni,omitempty"`
+	ReduceRtt            bool   `yaml:"reduce-rtt,omitempty"`
+	UdpRelayMode         string `yaml:"udp-relay-mode,omitempty"`
+	CongestionController string `yaml:"congestion-controller,omitempty"`
+	FastOpen             bool   `yaml:"fast-open,omitempty"`
+	DisableMTUDiscovery  bool   `yaml:"disable-mtu-discovery,omitempty"`
+	UDPOverStream        bool   `yaml:"udp-over-stream,omitempty"`
+}
+
+func (t *TuicOption) Build() any {
+	t.TLS = true
+	t.TFO = t.FastOpen
+	options := &option.TUICOutboundOptions{
+		DialerOptions:               t.DialerOptions.Build(),
+		ServerOptions:               t.ServerOptions.Build(),
+		UUID:                        t.UUID,
+		Password:                    t.Password,
+		CongestionControl:           t.CongestionController,
+		UDPRelayMode:                t.UdpRelayMode,
+		UDPOverStream:               t.UDPOverStream,
+		ZeroRTTHandshake:            t.ReduceRtt,
+		Heartbeat:                   badoption.Duration(t.HeartbeatInterval),
+		OutboundTLSOptionsContainer: clashTLSOptions(t.Server, &t.TLSOptions),
+	}
+	if t.Ip != "" {
+		options.Server = t.Ip
+	}
+	if t.DisableSni {
+		options.TLS.DisableSNI = true
+	}
+	return options
+}
+
+type VmessOption struct {
+	DialerOptions       `yaml:",inline"`
+	ServerOptions       `yaml:",inline"`
+	*TLSOptions         `yaml:",inline"`
+	UUID                string       `yaml:"uuid"`
+	AlterID             int          `yaml:"alterId"`
+	Cipher              string       `yaml:"cipher"`
+	UDP                 bool         `yaml:"udp,omitempty"`
+	Network             string       `yaml:"network,omitempty"`
+	ServerName          string       `yaml:"servername,omitempty"`
+	HTTPOpts            HTTPOptions  `yaml:"http-opts,omitempty"`
+	HTTP2Opts           HTTP2Options `yaml:"h2-opts,omitempty"`
+	GrpcOpts            GrpcOptions  `yaml:"grpc-opts,omitempty"`
+	WSOpts              WSOptions    `yaml:"ws-opts,omitempty"`
+	PacketAddr          bool         `yaml:"packet-addr,omitempty"`
+	XUDP                bool         `yaml:"xudp,omitempty"`
+	PacketEncoding      string       `yaml:"packet-encoding,omitempty"`
+	GlobalPadding       bool         `yaml:"global-padding,omitempty"`
+	AuthenticatedLength bool         `yaml:"authenticated-length,omitempty"`
+	MuxOpts             *MuxOptions  `yaml:"smux,omitempty"`
+}
+
+func (v *VmessOption) Build() any {
+	if v.TLSOptions != nil {
+		v.SNI = v.ServerName
+	}
+	switch v.PacketEncoding {
+	case "":
+		if v.XUDP {
+			v.PacketEncoding = "xudp"
+		} else if v.PacketAddr {
+			v.PacketEncoding = "packetaddr"
+		}
+	case "packet":
+		v.PacketEncoding = "packetaddr"
+	}
+	return &option.VMessOutboundOptions{
+		DialerOptions:               v.DialerOptions.Build(),
+		ServerOptions:               v.ServerOptions.Build(),
+		UUID:                        v.UUID,
+		Security:                    v.Cipher,
+		AlterId:                     v.AlterID,
+		GlobalPadding:               v.GlobalPadding,
+		AuthenticatedLength:         v.AuthenticatedLength,
+		Network:                     clashNetworks(v.UDP),
+		OutboundTLSOptionsContainer: clashTLSOptions(v.Server, v.TLSOptions),
+		PacketEncoding:              v.PacketEncoding,
+		Multiplex:                   v.MuxOpts.Build(),
+		Transport:                   clashTransport(v.Network, v.HTTPOpts, v.HTTP2Opts, v.GrpcOpts, v.WSOpts),
+	}
+}
+
+type VlessOption struct {
+	DialerOptions  `yaml:",inline"`
+	ServerOptions  `yaml:",inline"`
+	*TLSOptions    `yaml:",inline"`
+	UUID           string       `yaml:"uuid"`
+	Flow           string       `yaml:"flow,omitempty"`
+	UDP            bool         `yaml:"udp,omitempty"`
+	PacketAddr     bool         `yaml:"packet-addr,omitempty"`
+	XUDP           bool         `yaml:"xudp,omitempty"`
+	PacketEncoding string       `yaml:"packet-encoding,omitempty"`
+	Network        string       `yaml:"network,omitempty"`
+	ServerName     string       `yaml:"servername,omitempty"`
+	HTTPOpts       HTTPOptions  `yaml:"http-opts,omitempty"`
+	HTTP2Opts      HTTP2Options `yaml:"h2-opts,omitempty"`
+	GrpcOpts       GrpcOptions  `yaml:"grpc-opts,omitempty"`
+	WSOpts         WSOptions    `yaml:"ws-opts,omitempty"`
+	MuxOpts        *MuxOptions  `yaml:"smux,omitempty"`
+}
+
+func (v *VlessOption) Build() any {
+	if v.TLSOptions != nil {
+		v.SNI = v.ServerName
+	}
+	switch v.PacketEncoding {
+	case "":
+		if v.PacketAddr {
+			v.PacketEncoding = "packetaddr"
+		} else {
+			v.PacketEncoding = "xudp"
+		}
+	case "packet":
+		v.PacketEncoding = "packetaddr"
+	}
+	return &option.VLESSOutboundOptions{
+		DialerOptions:               v.DialerOptions.Build(),
+		ServerOptions:               v.ServerOptions.Build(),
+		UUID:                        v.UUID,
+		Flow:                        v.Flow,
+		Network:                     clashNetworks(v.UDP),
+		OutboundTLSOptionsContainer: clashTLSOptions(v.Server, v.TLSOptions),
+		Multiplex:                   v.MuxOpts.Build(),
+		Transport:                   clashTransport(v.Network, v.HTTPOpts, v.HTTP2Opts, v.GrpcOpts, v.WSOpts),
+		PacketEncoding:              &v.PacketEncoding,
+	}
+}
+
+type Socks5Option struct {
+	DialerOptions `yaml:",inline"`
+	ServerOptions `yaml:",inline"`
+	UserName      string `yaml:"username,omitempty"`
+	Password      string `yaml:"password,omitempty"`
+	UDP           bool   `yaml:"udp,omitempty"`
+}
+
+func (s *Socks5Option) Build() any {
+	return &option.SOCKSOutboundOptions{
+		DialerOptions: s.DialerOptions.Build(),
+		ServerOptions: s.ServerOptions.Build(),
+		Username:      s.UserName,
+		Password:      s.Password,
+		Network:       clashNetworks(s.UDP),
+	}
+}
+
+type HttpOption struct {
+	DialerOptions `yaml:",inline"`
+	ServerOptions `yaml:",inline"`
+	*TLSOptions   `yaml:",inline"`
+	UserName      string            `yaml:"username,omitempty"`
+	Password      string            `yaml:"password,omitempty"`
+	Headers       map[string]string `yaml:"headers,omitempty"`
+}
+
+func (h *HttpOption) Build() any {
+	return &option.HTTPOutboundOptions{
+		DialerOptions:               h.DialerOptions.Build(),
+		ServerOptions:               h.ServerOptions.Build(),
+		Username:                    h.UserName,
+		Password:                    h.Password,
+		OutboundTLSOptionsContainer: clashTLSOptions(h.Server, h.TLSOptions),
+		Headers:                     clashHeaders(h.Headers),
+	}
+}
+
+type TrojanOption struct {
+	DialerOptions `yaml:",inline"`
+	ServerOptions `yaml:",inline"`
+	TLSOptions    `yaml:",inline"`
+	Password      string      `yaml:"password"`
+	UDP           bool        `yaml:"udp,omitempty"`
+	Network       string      `yaml:"network,omitempty"`
+	GrpcOpts      GrpcOptions `yaml:"grpc-opts,omitempty"`
+	WSOpts        WSOptions   `yaml:"ws-opts,omitempty"`
+	MuxOpts       *MuxOptions `yaml:"smux,omitempty"`
+}
+
+func (t *TrojanOption) Build() any {
+	t.TLS = true
+	return &option.TrojanOutboundOptions{
+		DialerOptions:               t.DialerOptions.Build(),
+		ServerOptions:               t.ServerOptions.Build(),
+		Password:                    t.Password,
+		Network:                     clashNetworks(t.UDP),
+		OutboundTLSOptionsContainer: clashTLSOptions(t.Server, &t.TLSOptions),
+		Multiplex:                   t.MuxOpts.Build(),
+		Transport:                   clashTransport(t.Network, HTTPOptions{}, HTTP2Options{}, t.GrpcOpts, t.WSOpts),
+	}
+}
+
+type HysteriaOption struct {
+	DialerOptions       `yaml:",inline"`
+	ServerOptions       `yaml:",inline"`
+	TLSOptions          `yaml:",inline"`
+	Ports               string `yaml:"ports,omitempty"`
+	Up                  string `yaml:"up"`
+	UpSpeed             int    `yaml:"up-speed,omitempty"` // compatible with Stash
+	Down                string `yaml:"down"`
+	DownSpeed           int    `yaml:"down-speed,omitempty"` // compatible with Stash
+	Auth                string `yaml:"auth,omitempty"`
+	AuthString          string `yaml:"auth-str,omitempty"`
+	Obfs                string `yaml:"obfs,omitempty"`
+	ReceiveWindowConn   int    `yaml:"recv-window-conn,omitempty"`
+	ReceiveWindow       int    `yaml:"recv-window,omitempty"`
+	DisableMTUDiscovery bool   `yaml:"disable-mtu-discovery,omitempty"`
+	FastOpen            bool   `yaml:"fast-open,omitempty"`
+	HopInterval         int    `yaml:"hop-interval,omitempty"`
+}
+
+func (h *HysteriaOption) Build() any {
+	h.TLS = true
+	h.TFO = h.FastOpen
+	return &option.HysteriaOutboundOptions{
+		DialerOptions:               h.DialerOptions.Build(),
+		ServerOptions:               h.ServerOptions.Build(),
+		ServerPorts:                 clashPorts(h.Ports),
+		HopInterval:                 badoption.Duration(h.HopInterval),
+		Up:                          clashSpeedToNetworkBytes(h.Up),
+		UpMbps:                      h.UpSpeed,
+		Down:                        clashSpeedToNetworkBytes(h.Down),
+		DownMbps:                    h.DownSpeed,
+		Obfs:                        h.Obfs,
+		Auth:                        []byte(h.Auth),
+		AuthString:                  h.AuthString,
+		ReceiveWindowConn:           uint64(h.ReceiveWindowConn),
+		ReceiveWindow:               uint64(h.ReceiveWindow),
+		DisableMTUDiscovery:         h.DisableMTUDiscovery,
+		OutboundTLSOptionsContainer: clashTLSOptions(h.Server, &h.TLSOptions),
+	}
+}
+
+type Hysteria2Option struct {
+	DialerOptions `yaml:",inline"`
+	ServerOptions `yaml:",inline"`
+	TLSOptions    `yaml:",inline"`
+	Ports         string `yaml:"ports,omitempty"`
+	HopInterval   int    `yaml:"hop-interval,omitempty"`
+	Up            string `yaml:"up,omitempty"`
+	Down          string `yaml:"down,omitempty"`
+	Password      string `yaml:"password,omitempty"`
+	Obfs          string `yaml:"obfs,omitempty"`
+	ObfsPassword  string `yaml:"obfs-password,omitempty"`
+}
+
+func (h *Hysteria2Option) Build() any {
+	h.TLS = true
+	return &option.Hysteria2OutboundOptions{
+		DialerOptions:               h.DialerOptions.Build(),
+		ServerOptions:               h.ServerOptions.Build(),
+		ServerPorts:                 clashPorts(h.Ports),
+		HopInterval:                 badoption.Duration(h.HopInterval),
+		UpMbps:                      clashSpeedToIntMbps(h.Up),
+		DownMbps:                    clashSpeedToIntMbps(h.Down),
+		Obfs:                        clashHysteria2Obfs(h.Obfs, h.ObfsPassword),
+		Password:                    h.Password,
+		OutboundTLSOptionsContainer: clashTLSOptions(h.Server, &h.TLSOptions),
+	}
+}
+
+type SSHOption struct {
+	DialerOptions        `yaml:",inline"`
+	ServerOptions        `yaml:",inline"`
+	UserName             string   `yaml:"username"`
+	Password             string   `yaml:"password,omitempty"`
+	PrivateKey           string   `yaml:"private-key,omitempty"`
+	PrivateKeyPassphrase string   `yaml:"private-key-passphrase,omitempty"`
+	HostKey              []string `yaml:"host-key,omitempty"`
+	HostKeyAlgorithms    []string `yaml:"host-key-algorithms,omitempty"`
+}
+
+func (s *SSHOption) Build() any {
+	options := &option.SSHOutboundOptions{
+		DialerOptions:        s.DialerOptions.Build(),
+		ServerOptions:        s.ServerOptions.Build(),
+		User:                 s.UserName,
+		Password:             s.Password,
+		PrivateKeyPassphrase: s.PrivateKeyPassphrase,
+		HostKey:              s.HostKey,
+		HostKeyAlgorithms:    s.HostKeyAlgorithms,
+	}
+	if strings.Contains(s.PrivateKey, "PRIVATE KEY") {
+		options.PrivateKey = trimStringArray(strings.Split(s.PrivateKey, "\n"))
+	} else {
+		options.PrivateKeyPath = s.PrivateKey
+	}
+	return options
+}
+
+type AnyTLSOption struct {
+	DialerOptions            `yaml:",inline"`
+	ServerOptions            `yaml:",inline"`
+	TLSOptions               `yaml:",inline"`
+	Password                 string `yaml:"password"`
+	UDP                      bool   `yaml:"udp,omitempty"`
+	IdleSessionCheckInterval int    `yaml:"idle-session-check-interval,omitempty"`
+	IdleSessionTimeout       int    `yaml:"idle-session-timeout,omitempty"`
+	MinIdleSession           int    `yaml:"min-idle-session,omitempty"`
+}
+
+func (a *AnyTLSOption) Build() any {
+	a.TLS = true
+	return &option.AnyTLSOutboundOptions{
+		DialerOptions:               a.DialerOptions.Build(),
+		ServerOptions:               a.ServerOptions.Build(),
+		OutboundTLSOptionsContainer: clashTLSOptions(a.Server, &a.TLSOptions),
+		Password:                    a.Password,
+		IdleSessionCheckInterval:    badoption.Duration(a.IdleSessionCheckInterval),
+		IdleSessionTimeout:          badoption.Duration(a.IdleSessionTimeout),
+		MinIdleSession:              a.MinIdleSession,
+	}
+}
+
+type HTTPOptions struct {
+	Method  string               `yaml:"method,omitempty"`
+	Path    []string             `yaml:"path,omitempty"`
+	Headers badoption.HTTPHeader `yaml:"headers,omitempty"`
+}
+
+type HTTP2Options struct {
+	Host []string `yaml:"host,omitempty"`
+	Path string   `yaml:"path,omitempty"`
+}
+
+type GrpcOptions struct {
+	GrpcServiceName string `yaml:"grpc-service-name,omitempty"`
+}
+
+type WSOptions struct {
+	Path                string            `yaml:"path,omitempty"`
+	Headers             map[string]string `yaml:"headers,omitempty"`
+	MaxEarlyData        int               `yaml:"max-early-data,omitempty"`
+	EarlyDataHeaderName string            `yaml:"early-data-header-name,omitempty"`
+	V2rayHttpUpgrade    bool              `yaml:"v2ray-http-upgrade,omitempty"`
+}
+
+type MuxOptions struct {
+	Enabled        bool           `yaml:"enabled,omitempty"`
+	Protocol       string         `yaml:"protocol,omitempty"`
+	MaxConnections int            `yaml:"max-connections,omitempty"`
+	MinStreams     int            `yaml:"min-streams,omitempty"`
+	MaxStreams     int            `yaml:"max-streams,omitempty"`
+	Padding        bool           `yaml:"padding,omitempty"`
+	BrutalOpts     *BrutalOptions `yaml:"brutal-opts,omitempty"`
+}
+
+func (s *MuxOptions) Build() *option.OutboundMultiplexOptions {
+	if s == nil {
+		return nil
+	}
+	return &option.OutboundMultiplexOptions{
+		Enabled:        s.Enabled,
+		Protocol:       s.Protocol,
+		MaxConnections: s.MaxConnections,
+		MinStreams:     s.MinStreams,
+		MaxStreams:     s.MaxStreams,
+		Padding:        s.Padding,
+		Brutal:         s.BrutalOpts.Build(),
+	}
+}
+
+type BrutalOptions struct {
+	Enabled bool   `yaml:"enabled,omitempty"`
+	Up      string `yaml:"up,omitempty"`
+	Down    string `yaml:"down,omitempty"`
+}
+
+func (b *BrutalOptions) Build() *option.BrutalOptions {
+	if b == nil {
+		return nil
+	}
+	return &option.BrutalOptions{
+		Enabled:  b.Enabled,
+		UpMbps:   clashSpeedToIntMbps(b.Up),
+		DownMbps: clashSpeedToIntMbps(b.Down),
+	}
+}
+
+type RealityOptions struct {
+	PublicKey string `yaml:"public-key"`
+	ShortID   string `yaml:"short-id"`
+}
+
+func (r *RealityOptions) Build() *option.OutboundRealityOptions {
+	if r == nil {
+		return nil
+	}
+	return &option.OutboundRealityOptions{
+		Enabled:   true,
+		PublicKey: r.PublicKey,
+		ShortID:   r.ShortID,
+	}
+}
+
+type ECHOptions struct {
+	Enable bool   `yaml:"enable,omitempty"`
+	Config string `yaml:"config,omitempty"`
+}
+
+func (e *ECHOptions) Build() *option.OutboundECHOptions {
+	if e == nil {
+		return nil
+	}
+	list, err := base64.StdEncoding.DecodeString(e.Config)
+	if err != nil {
+		return nil
+	}
+	return &option.OutboundECHOptions{
+		Enabled: e.Enable,
+		Config:  trimStringArray(strings.Split(string(list), "\n")),
+	}
+}
+
+type TLSOptions struct {
+	TLS               bool            `yaml:"tls,omitempty"`
+	SNI               string          `yaml:"sni,omitempty"`
+	SkipCertVerify    bool            `yaml:"skip-cert-verify,omitempty"`
+	ALPN              []string        `yaml:"alpn,omitempty"`
+	ClientFingerprint string          `yaml:"client-fingerprint,omitempty"`
+	CustomCA          string          `yaml:"ca,omitempty"`
+	CustomCAString    string          `yaml:"ca-str,omitempty"`
+	Certificate       string          `yaml:"certificate,omitempty"`
+	PrivateKey        string          `yaml:"private-key,omitempty"`
+	ECHOpts           *ECHOptions     `yaml:"ech-opts,omitempty"`
+	RealityOpts       *RealityOptions `yaml:"reality-opts,omitempty"`
+}
+
+func (t *TLSOptions) Build() *option.OutboundTLSOptions {
+	if t == nil {
+		return nil
+	}
+	options := &option.OutboundTLSOptions{
+		Enabled:         t.TLS,
+		ServerName:      t.SNI,
+		Insecure:        t.SkipCertVerify,
+		ALPN:            t.ALPN,
+		UTLS:            clashClientFingerprint(t.ClientFingerprint),
+		Certificate:     trimStringArray(strings.Split(t.CustomCAString, "\n")),
+		CertificatePath: t.CustomCA,
+		ECH:             t.ECHOpts.Build(),
+		Reality:         t.RealityOpts.Build(),
+	}
+	if strings.HasPrefix(t.Certificate, "-----BEGIN ") {
+		options.ClientCertificate = trimStringArray(strings.Split(t.Certificate, "\n"))
+	} else {
+		options.ClientCertificatePath = t.Certificate
+	}
+	if strings.HasPrefix(t.PrivateKey, "-----BEGIN ") {
+		options.ClientKey = trimStringArray(strings.Split(t.PrivateKey, "\n"))
+	} else {
+		options.ClientKeyPath = t.PrivateKey
+	}
+	return options
+}
+
+type DialerOptions struct {
+	TFO         bool   `yaml:"tfo,omitempty"`
+	MPTCP       bool   `yaml:"mptcp,omitempty"`
+	Interface   string `yaml:"interface-name,omitempty"`
+	RoutingMark int    `yaml:"routing-mark,omitempty"`
+	DialerProxy string `yaml:"dialer-proxy,omitempty"`
+}
+
+func (b *DialerOptions) Build() option.DialerOptions {
+	return option.DialerOptions{
+		Detour:        b.DialerProxy,
+		BindInterface: b.Interface,
+		TCPFastOpen:   b.TFO,
+		TCPMultiPath:  b.MPTCP,
+		RoutingMark:   option.FwMark(b.RoutingMark),
+	}
+}
+
+type ServerOptions struct {
+	Server string `yaml:"server"`
+	Port   int    `yaml:"port"`
+}
+
+func (s *ServerOptions) Build() option.ServerOptions {
+	return option.ServerOptions{
+		Server:     s.Server,
+		ServerPort: uint16(s.Port),
+	}
+}
+
+type shadowsocksPluginOptionsBuilder map[string]any
+
+func (o shadowsocksPluginOptionsBuilder) Build() string {
+	var opts []string
+	for key, value := range o {
+		if value == nil {
+			continue
+		}
+		opts = append(opts, F.ToString(key, "=", value))
+	}
+	return strings.Join(opts, ";")
+}
+
+func clashClientFingerprint(clientFingerprint string) *option.OutboundUTLSOptions {
+	if clientFingerprint == "" {
+		return nil
+	}
+	return &option.OutboundUTLSOptions{
+		Enabled:     true,
+		Fingerprint: clientFingerprint,
+	}
+}
+
+func clashHeaders(headers map[string]string) map[string]badoption.Listable[string] {
+	if headers == nil {
+		return nil
+	}
+	result := make(map[string]badoption.Listable[string])
+	for key, value := range headers {
+		result[key] = []string{value}
+	}
+	return result
+}
+
+func clashHysteria2Obfs(obfs string, password string) *option.Hysteria2Obfs {
+	if obfs == "" {
+		return nil
+	}
+	return &option.Hysteria2Obfs{
+		Type:     obfs,
+		Password: password,
+	}
+}
+
+func clashNetworks(udpEnabled bool) option.NetworkList {
+	if !udpEnabled {
+		return N.NetworkTCP
+	}
+	return ""
+}
+
+func clashPluginName(plugin string) string {
+	switch plugin {
+	case "obfs":
+		return "obfs-local"
+	}
+	return plugin
+}
+
+func clashPluginOptions(plugin string, opts map[string]any) string {
+	options := make(shadowsocksPluginOptionsBuilder)
+	switch plugin {
+	case "obfs":
+		options["obfs"] = opts["mode"]
+		options["obfs-host"] = opts["host"]
+	case "v2ray-plugin":
+		options["mode"] = opts["mode"]
+		options["tls"] = opts["tls"]
+		options["host"] = opts["host"]
+		options["path"] = opts["path"]
+	}
+	return options.Build()
+}
+
+func clashPorts(ports string) badoption.Listable[string] {
+	if ports == "" {
+		return nil
+	}
+	serverPorts := badoption.Listable[string]{}
+	ports = strings.ReplaceAll(ports, "/", ",")
+	for _, port := range strings.Split(ports, ",") {
+		if port == "" {
+			continue
+		}
+		port = strings.Replace(port, "-", ":", 1)
+		serverPorts = append(serverPorts, port)
+	}
+	return serverPorts
+}
+
+func clashShadowsocksCipher(cipher string) string {
+	switch cipher {
+	case "dummy":
+		return "none"
+	}
+	return cipher
+}
+
+func clashStringList(list []string) string {
+	if len(list) > 0 {
+		return list[0]
+	}
+	return ""
+}
+
+func clashSpeedToIntMbps(speed string) int {
+	if speed == "" {
+		return 0
+	}
+	if num, err := strconv.Atoi(speed); err == nil {
+		return num
+	}
+	networkBytes := byteformats.NetworkBytesCompat{}
+	if err := networkBytes.UnmarshalJSON([]byte(speed)); err != nil {
+		return 0
+	}
+	return int(networkBytes.Value() / byteformats.MByte * 8)
+}
+
+func clashSpeedToNetworkBytes(speed string) *byteformats.NetworkBytesCompat {
+	if speed == "" {
+		return nil
+	}
+	networkBytes := &byteformats.NetworkBytesCompat{}
+	if num, err := strconv.Atoi(speed); err == nil {
+		speed = F.ToString(num, "Mbps")
+	}
+	if err := networkBytes.UnmarshalJSON([]byte(speed)); err != nil {
+		return nil
+	}
+	return networkBytes
+}
+
+func clashTransport(network string, httpOpts HTTPOptions, h2Opts HTTP2Options, grpcOpts GrpcOptions, wsOpts WSOptions) *option.V2RayTransportOptions {
+	switch network {
+	case "http":
+		return &option.V2RayTransportOptions{
+			Type: C.V2RayTransportTypeHTTP,
+			HTTPOptions: option.V2RayHTTPOptions{
+				Method:  httpOpts.Method,
+				Path:    clashStringList(httpOpts.Path),
+				Headers: httpOpts.Headers,
+			},
+		}
+	case "h2":
+		return &option.V2RayTransportOptions{
+			Type: C.V2RayTransportTypeHTTP,
+			HTTPOptions: option.V2RayHTTPOptions{
+				Path: h2Opts.Path,
+				Host: h2Opts.Host,
+			},
+		}
+	case "grpc":
+		return &option.V2RayTransportOptions{
+			Type: C.V2RayTransportTypeGRPC,
+			GRPCOptions: option.V2RayGRPCOptions{
+				ServiceName: grpcOpts.GrpcServiceName,
+			},
+		}
+	case "ws":
+		headers := clashHeaders(wsOpts.Headers)
+		if wsOpts.V2rayHttpUpgrade {
+			var host string
+			if headers != nil && headers["Host"] != nil {
+				host = headers["Host"][0]
+			}
+			return &option.V2RayTransportOptions{
+				Type: C.V2RayTransportTypeHTTPUpgrade,
+				HTTPUpgradeOptions: option.V2RayHTTPUpgradeOptions{
+					Host:    host,
+					Path:    wsOpts.Path,
+					Headers: headers,
+				},
+			}
+		}
+		return &option.V2RayTransportOptions{
+			Type: C.V2RayTransportTypeWebsocket,
+			WebsocketOptions: option.V2RayWebsocketOptions{
+				Path:                wsOpts.Path,
+				Headers:             headers,
+				MaxEarlyData:        uint32(wsOpts.MaxEarlyData),
+				EarlyDataHeaderName: wsOpts.EarlyDataHeaderName,
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func clashTLSOptions(server string, tlsOptions *TLSOptions) option.OutboundTLSOptionsContainer {
+	if tlsOptions != nil && tlsOptions.SNI == "" {
+		tlsOptions.SNI = server
+	}
+	return option.OutboundTLSOptionsContainer{
+		TLS: tlsOptions.Build(),
+	}
+}
+
+func trimStringArray(array []string) []string {
+	return common.Filter(array, func(it string) bool {
+		return strings.TrimSpace(it) != ""
+	})
+}

--- a/provider/parser/link.go
+++ b/provider/parser/link.go
@@ -1,0 +1,662 @@
+package parser
+
+import (
+	"net/url"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/byteformats"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/common/json/badoption"
+)
+
+func ParseSubscriptionLink(link string) (option.Outbound, error) {
+	reg := regexp.MustCompile(`^(.*?)(://)(.*?)([@?#].*)?$`)
+	result := reg.FindStringSubmatch(link)
+	if result == nil {
+		return option.Outbound{}, E.New("invalid link")
+	}
+
+	scheme := result[1]
+	switch scheme {
+	case "tuic":
+		return parseTuicLink(link)
+	case "trojan":
+		return parseTrojanLink(link)
+	case "vless":
+		return parseVLESSLink(link)
+	case "hysteria":
+		return parseHysteriaLink(link)
+	case "hy2", "hysteria2":
+		return parseHysteria2Link(link)
+	}
+	result[3], _ = DecodeBase64URLSafe(result[3])
+	link = strings.Join(result[1:], "")
+	switch scheme {
+	case "ss":
+		return parseShadowsocksLink(link)
+	case "vmess":
+		return parseVMessLink(link)
+	default:
+		return option.Outbound{}, E.New("unsupported scheme: ", scheme)
+	}
+}
+
+func StringToType[T any](str string) T {
+	var value T
+	v := reflect.ValueOf(&value).Elem()
+	switch any(value).(type) {
+	case badoption.Duration:
+		d, err := time.ParseDuration(str)
+		if err != nil {
+			v.SetInt(StringToType[int64](str))
+		} else {
+			v.Set(reflect.ValueOf(d))
+		}
+		return value
+	case badoption.HTTPHeader:
+		headers := badoption.HTTPHeader{}
+		reg := regexp.MustCompile(`^[ \t]*?(\S+?):[ \t]*?(\S+?)[ \t]*?$`)
+		for _, header := range strings.Split(str, "\n") {
+			result := reg.FindStringSubmatch(header)
+			if result != nil {
+				key := result[1]
+				headers[key] = strings.Split(result[2], ",")
+			}
+		}
+		v.Set(reflect.ValueOf(headers))
+		return value
+	}
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, _ := strconv.ParseInt(str, 10, 64)
+		v.SetInt(i)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		i, _ := strconv.ParseUint(str, 10, 64)
+		v.SetUint(i)
+	case reflect.Float32, reflect.Float64:
+		f, _ := strconv.ParseFloat(str, 64)
+		v.SetFloat(f)
+	case reflect.Bool:
+		b, _ := strconv.ParseBool(str)
+		v.SetBool(b)
+	default:
+		panic("unsupported type")
+	}
+	return value
+}
+
+func shadowsocksPluginName(plugin string) string {
+	if index := strings.Index(plugin, ";"); index != -1 {
+		return plugin[:index]
+	}
+	return plugin
+}
+
+func shadowsocksPluginOptions(plugin string) string {
+	if index := strings.Index(plugin, ";"); index != -1 {
+		return plugin[index+1:]
+	}
+	return ""
+}
+
+func v2rayTransportWsPath(WebsocketOptions *option.V2RayWebsocketOptions, path string) {
+	reg := regexp.MustCompile(`^(.*?)(?:\?ed=(\d*))?$`)
+	result := reg.FindStringSubmatch(path)
+	WebsocketOptions.Path = result[1]
+	if result[2] != "" {
+		WebsocketOptions.EarlyDataHeaderName = "Sec-WebSocket-Protocol"
+		WebsocketOptions.MaxEarlyData = StringToType[uint32](result[2])
+	}
+}
+
+func v2rayTransportWs(host string, path string) option.V2RayWebsocketOptions {
+	var WebsocketOptions option.V2RayWebsocketOptions
+	if host != "" {
+		WebsocketOptions.Headers = StringToType[badoption.HTTPHeader](F.ToString("Host: ", host))
+	}
+	if path != "" {
+		v2rayTransportWsPath(&WebsocketOptions, path)
+	}
+	return WebsocketOptions
+}
+
+func parseShadowsocksLink(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	if linkURL.User == nil || linkURL.User.Username() == "" {
+		return option.Outbound{}, E.New("missing user info")
+	}
+	var options option.ShadowsocksOutboundOptions
+	options.ServerOptions.Server = linkURL.Hostname()
+	options.ServerOptions.ServerPort = StringToType[uint16](linkURL.Port())
+	password, _ := linkURL.User.Password()
+	if password == "" {
+		return option.Outbound{}, E.New("bad user info")
+	}
+	options.Method = linkURL.User.Username()
+	options.Password = password
+	plugin := linkURL.Query().Get("plugin")
+	options.Plugin = shadowsocksPluginName(plugin)
+	options.PluginOptions = shadowsocksPluginOptions(plugin)
+
+	outbound := option.Outbound{
+		Type: C.TypeShadowsocks,
+		Tag:  linkURL.Fragment,
+	}
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseTuicLink(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	if linkURL.User == nil || linkURL.User.Username() == "" {
+		return option.Outbound{}, E.New("missing uuid")
+	}
+	var options option.TUICOutboundOptions
+	TLSOptions := option.OutboundTLSOptions{
+		Enabled: true,
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	options.UUID = linkURL.User.Username()
+	options.Password, _ = linkURL.User.Password()
+	options.ServerOptions.Server = linkURL.Hostname()
+	TLSOptions.ServerName = linkURL.Hostname()
+	options.ServerOptions.ServerPort = StringToType[uint16](linkURL.Port())
+	for key, values := range linkURL.Query() {
+		value := values[0]
+		switch key {
+		case "congestion_control":
+			if value != "cubic" {
+				options.CongestionControl = value
+			}
+		case "udp_relay_mode":
+			options.UDPRelayMode = value
+		case "udp_over_stream":
+			if value == "true" || value == "1" {
+				options.UDPOverStream = true
+			}
+		case "zero_rtt_handshake", "reduce_rtt":
+			if value == "true" || value == "1" {
+				options.ZeroRTTHandshake = true
+			}
+		case "heartbeat_interval":
+			options.Heartbeat = StringToType[badoption.Duration](value)
+		case "sni":
+			TLSOptions.ServerName = value
+		case "insecure", "skip-cert-verify", "allow_insecure":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		case "disable_sni":
+			if value == "1" || value == "true" {
+				TLSOptions.DisableSNI = true
+			}
+		case "tfo", "tcp-fast-open", "tcp_fast_open":
+			if value == "1" || value == "true" {
+				options.TCPFastOpen = true
+			}
+		case "alpn":
+			TLSOptions.ALPN = strings.Split(value, ",")
+		}
+	}
+	if options.UDPOverStream {
+		options.UDPRelayMode = ""
+	}
+	outbound := option.Outbound{
+		Type: C.TypeTUIC,
+		Tag:  linkURL.Fragment,
+	}
+	options.TLS = &TLSOptions
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseVMessLink(link string) (option.Outbound, error) {
+	var proxy map[string]string
+	reg := regexp.MustCompile(`(\"[^:,]+?\"[ \t]*:[ \t]*)(\d+|true|false)`)
+	s := reg.ReplaceAllString(link, `$1"$2"`)
+	err := json.Unmarshal([]byte(s[8:]), &proxy)
+	if err != nil {
+		proxy = make(map[string]string)
+		linkURL, err := url.Parse(link)
+		if err != nil {
+			return option.Outbound{}, err
+		}
+		if linkURL.User == nil || linkURL.User.Username() == "" {
+			return option.Outbound{}, E.New("missing uuid")
+		}
+		proxy["id"] = linkURL.User.Username()
+		proxy["add"] = linkURL.Hostname()
+		proxy["port"] = linkURL.Port()
+		proxy["ps"] = linkURL.Fragment
+		for key, values := range linkURL.Query() {
+			value := values[0]
+			switch key {
+			case "type":
+				if value == "http" {
+					proxy["net"] = "tcp"
+					proxy["type"] = "http"
+				}
+			case "encryption":
+				proxy["scy"] = value
+			case "alterId":
+				proxy["aid"] = value
+			case "key", "alpn", "seed", "path", "host":
+				proxy[key] = value
+			default:
+				proxy[key] = value
+			}
+		}
+	}
+	outbound := option.Outbound{
+		Type: C.TypeVMess,
+	}
+	options := option.VMessOutboundOptions{
+		Security: "auto",
+	}
+	TLSOptions := option.OutboundTLSOptions{
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	for key, value := range proxy {
+		switch key {
+		case "ps":
+			outbound.Tag = value
+		case "add":
+			options.Server = value
+			TLSOptions.ServerName = value
+		case "port":
+			options.ServerPort = StringToType[uint16](value)
+		case "id":
+			options.UUID = value
+		case "scy":
+			options.Security = value
+		case "aid":
+			options.AlterId, _ = strconv.Atoi(value)
+		case "packet_encoding":
+			options.PacketEncoding = value
+		case "xudp":
+			if value == "1" || value == "true" {
+				options.PacketEncoding = "xudp"
+			}
+		case "tls":
+			if value == "1" || value == "true" || value == "tls" {
+				TLSOptions.Enabled = true
+			}
+		case "insecure", "skip-cert-verify":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		case "fp":
+			TLSOptions.UTLS.Enabled = true
+			TLSOptions.UTLS.Fingerprint = value
+		case "net":
+			Transport := option.V2RayTransportOptions{
+				Type: "",
+				WebsocketOptions: option.V2RayWebsocketOptions{
+					Headers: badoption.HTTPHeader{},
+				},
+				HTTPOptions: option.V2RayHTTPOptions{
+					Host:    badoption.Listable[string]{},
+					Headers: map[string]badoption.Listable[string]{},
+				},
+				GRPCOptions: option.V2RayGRPCOptions{},
+			}
+			switch value {
+			case "ws":
+				Transport.Type = C.V2RayTransportTypeWebsocket
+				Transport.WebsocketOptions = v2rayTransportWs(proxy["host"], proxy["path"])
+			case "h2":
+				Transport.Type = C.V2RayTransportTypeHTTP
+				TLSOptions.Enabled = true
+				if host, exists := proxy["host"]; exists && host != "" {
+					Transport.HTTPOptions.Host = []string{host}
+				}
+				if path, exists := proxy["path"]; exists && path != "" {
+					Transport.HTTPOptions.Path = path
+				}
+			case "tcp":
+				if tType, exists := proxy["type"]; exists {
+					if tType != "http" {
+						continue
+					}
+					Transport.Type = C.V2RayTransportTypeHTTP
+					if method, exists := proxy["method"]; exists {
+						Transport.HTTPOptions.Method = method
+					}
+					if host, exists := proxy["host"]; exists && host != "" {
+						Transport.HTTPOptions.Host = []string{host}
+					}
+					if path, exists := proxy["path"]; exists && path != "" {
+						Transport.HTTPOptions.Path = path
+					}
+					if headers, exists := proxy["headers"]; exists {
+						Transport.HTTPOptions.Headers = StringToType[badoption.HTTPHeader](headers)
+					}
+				}
+			case "grpc":
+				Transport.Type = C.V2RayTransportTypeGRPC
+				if host, exists := proxy["host"]; exists && host != "" {
+					Transport.GRPCOptions.ServiceName = host
+				}
+			default:
+				continue
+			}
+			options.Transport = &Transport
+		case "tfo", "tcp-fast-open", "tcp_fast_open":
+			if value == "1" || value == "true" {
+				options.TCPFastOpen = true
+			}
+		}
+	}
+	if TLSOptions.Enabled {
+		options.TLS = &TLSOptions
+	}
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseVLESSLink(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	if linkURL.User == nil || linkURL.User.Username() == "" {
+		return option.Outbound{}, E.New("missing uuid")
+	}
+	var options option.VLESSOutboundOptions
+	TLSOptions := option.OutboundTLSOptions{
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	options.UUID = linkURL.User.Username()
+	options.Server = linkURL.Hostname()
+	TLSOptions.ServerName = linkURL.Hostname()
+	options.ServerPort = StringToType[uint16](linkURL.Port())
+	proxy := map[string]string{}
+	for key, values := range linkURL.Query() {
+		value := values[0]
+		switch key {
+		case "key", "alpn", "seed", "path", "host":
+			proxy[key] = value
+		default:
+			proxy[key] = value
+		}
+	}
+	for key, value := range proxy {
+		switch key {
+		case "type":
+			Transport := option.V2RayTransportOptions{
+				HTTPOptions: option.V2RayHTTPOptions{
+					Host:    badoption.Listable[string]{},
+					Headers: badoption.HTTPHeader{},
+				},
+				GRPCOptions: option.V2RayGRPCOptions{},
+			}
+			switch value {
+			case "ws":
+				Transport.Type = C.V2RayTransportTypeWebsocket
+				Transport.WebsocketOptions = v2rayTransportWs(proxy["host"], proxy["path"])
+			case "http":
+				Transport.Type = C.V2RayTransportTypeHTTP
+				if host, exists := proxy["host"]; exists && host != "" {
+					Transport.HTTPOptions.Host = strings.Split(host, ",")
+				}
+				if path, exists := proxy["path"]; exists && path != "" {
+					Transport.HTTPOptions.Path = path
+				}
+			case "grpc":
+				Transport.Type = C.V2RayTransportTypeGRPC
+				if serviceName, exists := proxy["serviceName"]; exists && serviceName != "" {
+					Transport.GRPCOptions.ServiceName = serviceName
+				}
+			default:
+				continue
+			}
+			options.Transport = &Transport
+		case "security":
+			if value == "tls" {
+				TLSOptions.Enabled = true
+			} else if value == "reality" {
+				TLSOptions.Enabled = true
+				TLSOptions.Reality.Enabled = true
+			}
+		case "insecure", "skip-cert-verify":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		case "serviceName", "sni", "peer":
+			TLSOptions.ServerName = value
+		case "alpn":
+			TLSOptions.ALPN = strings.Split(value, ",")
+		case "fp":
+			TLSOptions.UTLS.Enabled = true
+			TLSOptions.UTLS.Fingerprint = value
+		case "flow":
+			if value == "xtls-rprx-vision" {
+				options.Flow = "xtls-rprx-vision"
+			}
+		case "pbk":
+			TLSOptions.Reality.PublicKey = value
+		case "sid":
+			TLSOptions.Reality.ShortID = value
+		case "tfo", "tcp-fast-open", "tcp_fast_open":
+			if value == "1" || value == "true" {
+				options.TCPFastOpen = true
+			}
+		}
+	}
+	outbound := option.Outbound{
+		Type: C.TypeVLESS,
+		Tag:  linkURL.Fragment,
+	}
+	if TLSOptions.Enabled {
+		options.TLS = &TLSOptions
+	}
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseTrojanLink(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	if linkURL.User == nil || linkURL.User.Username() == "" {
+		return option.Outbound{}, E.New("missing password")
+	}
+	var options option.TrojanOutboundOptions
+	TLSOptions := option.OutboundTLSOptions{
+		Enabled: true,
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	options.Server = linkURL.Hostname()
+	TLSOptions.ServerName = linkURL.Hostname()
+	options.ServerPort = StringToType[uint16](linkURL.Port())
+	options.Password = linkURL.User.Username()
+	proxy := map[string]string{}
+	for key, values := range linkURL.Query() {
+		value := values[0]
+		proxy[key] = value
+	}
+	for key, value := range proxy {
+		switch key {
+		case "insecure", "allowInsecure", "skip-cert-verify":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		case "serviceName", "sni", "peer":
+			TLSOptions.ServerName = value
+		case "alpn":
+			TLSOptions.ALPN = strings.Split(value, ",")
+		case "fp":
+			TLSOptions.UTLS.Enabled = true
+			TLSOptions.UTLS.Fingerprint = value
+		case "type":
+			Transport := option.V2RayTransportOptions{
+				Type: "",
+				WebsocketOptions: option.V2RayWebsocketOptions{
+					Headers: map[string]badoption.Listable[string]{},
+				},
+				HTTPOptions: option.V2RayHTTPOptions{
+					Host:    badoption.Listable[string]{},
+					Headers: map[string]badoption.Listable[string]{},
+				},
+				GRPCOptions: option.V2RayGRPCOptions{},
+			}
+			switch value {
+			case "ws":
+				Transport.Type = C.V2RayTransportTypeWebsocket
+				Transport.WebsocketOptions = v2rayTransportWs(proxy["host"], proxy["path"])
+			case "grpc":
+				Transport.Type = C.V2RayTransportTypeGRPC
+				if serviceName, exists := proxy["grpc-service-name"]; exists && serviceName != "" {
+					Transport.GRPCOptions.ServiceName = serviceName
+				}
+			default:
+				continue
+			}
+			options.Transport = &Transport
+		case "tfo", "tcp-fast-open", "tcp_fast_open":
+			if value == "1" || value == "true" {
+				options.TCPFastOpen = true
+			}
+		}
+	}
+	outbound := option.Outbound{
+		Type: C.TypeTrojan,
+		Tag:  linkURL.Fragment,
+	}
+	options.TLS = &TLSOptions
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseHysteriaLink(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	var options option.HysteriaOutboundOptions
+	TLSOptions := option.OutboundTLSOptions{
+		Enabled: true,
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	options.Server = linkURL.Hostname()
+	TLSOptions.ServerName = linkURL.Hostname()
+	options.ServerPort = StringToType[uint16](linkURL.Port())
+	for key, values := range linkURL.Query() {
+		value := values[0]
+		switch key {
+		case "auth":
+			options.AuthString = value
+		case "peer", "sni":
+			TLSOptions.ServerName = value
+		case "alpn":
+			TLSOptions.ALPN = strings.Split(value, ",")
+		case "ca":
+			TLSOptions.CertificatePath = value
+		case "ca_str":
+			TLSOptions.Certificate = strings.Split(value, "\n")
+		case "up":
+			options.Up = &byteformats.NetworkBytesCompat{}
+			options.Up.UnmarshalJSON([]byte(value))
+		case "up_mbps":
+			options.UpMbps, _ = strconv.Atoi(value)
+		case "down":
+			options.Down = &byteformats.NetworkBytesCompat{}
+			options.Down.UnmarshalJSON([]byte(value))
+		case "down_mbps":
+			options.DownMbps, _ = strconv.Atoi(value)
+		case "obfs", "obfsParam":
+			options.Obfs = value
+		case "insecure", "skip-cert-verify":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		case "tfo", "tcp-fast-open", "tcp_fast_open":
+			if value == "1" || value == "true" {
+				options.TCPFastOpen = true
+			}
+		}
+	}
+	outbound := option.Outbound{
+		Type: C.TypeHysteria,
+		Tag:  linkURL.Fragment,
+	}
+	options.TLS = &TLSOptions
+	outbound.Options = &options
+	return outbound, nil
+}
+
+func parseHysteria2Link(link string) (option.Outbound, error) {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return option.Outbound{}, err
+	}
+	var options option.Hysteria2OutboundOptions
+	TLSOptions := option.OutboundTLSOptions{
+		Enabled: true,
+		ECH:     &option.OutboundECHOptions{},
+		UTLS:    &option.OutboundUTLSOptions{},
+		Reality: &option.OutboundRealityOptions{},
+	}
+	Obfs := &option.Hysteria2Obfs{}
+	options.ServerPort = uint16(443)
+	options.Server = linkURL.Hostname()
+	TLSOptions.ServerName = linkURL.Hostname()
+	if linkURL.User != nil {
+		options.Password = linkURL.User.Username()
+	}
+	if linkURL.Port() != "" {
+		options.ServerPort = StringToType[uint16](linkURL.Port())
+	}
+	for key, values := range linkURL.Query() {
+		value := values[0]
+		switch key {
+		case "up":
+			options.UpMbps, _ = strconv.Atoi(value)
+		case "down":
+			options.DownMbps, _ = strconv.Atoi(value)
+		case "obfs":
+			if value == "salamander" {
+				Obfs.Type = "salamander"
+				options.Obfs = Obfs
+			}
+		case "obfs-password":
+			Obfs.Password = value
+		case "insecure", "skip-cert-verify":
+			if value == "1" || value == "true" {
+				TLSOptions.Insecure = true
+			}
+		}
+	}
+	outbound := option.Outbound{
+		Type: C.TypeHysteria2,
+		Tag:  linkURL.Fragment,
+	}
+	options.TLS = &TLSOptions
+	outbound.Options = &options
+	return outbound, nil
+}

--- a/provider/parser/link.go
+++ b/provider/parser/link.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"net/url"
 	"reflect"
 	"regexp"
@@ -8,16 +9,42 @@ import (
 	"strings"
 	"time"
 
+	Xbadoption "github.com/sagernet/sing-box/common/xray/json/badoption"
 	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/byteformats"
 	E "github.com/sagernet/sing/common/exceptions"
 	F "github.com/sagernet/sing/common/format"
-	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/common/logger"
+
+	// "github.com/sagernet/sing/common/json"
 	"github.com/sagernet/sing/common/json/badoption"
 )
 
-func ParseSubscriptionLink(link string) (option.Outbound, error) {
+// SubscriptionParser - парсер подписок с логгером.
+type SubscriptionParser struct {
+	logger logger.ContextLogger
+}
+
+// PERF: Костыльно, хотелось бы переделать.
+// NewSubscriptionParser создаёт новый парсер с указанным логгером.
+func NewSubscriptionParser(logger log.ContextLogger) *SubscriptionParser {
+	return &SubscriptionParser{logger: logger}
+}
+
+// PERF: Костыльно, хотелось бы переделать.
+// SetLogger устанавливает логгер для парсера по умолчанию.
+// Вызовите эту функцию при инициализации для использования логгера с тегом "parser".
+func SetLogger(l log.ContextLogger) {
+	defaultParser = NewSubscriptionParser(l)
+}
+
+// PERF: Костыльно, хотелось бы переделать.
+var defaultParser = NewSubscriptionParser(log.StdLogger())
+
+// ParseSubscriptionLink парсит ссылку подписки и возвращает опции outbound.
+func (s *SubscriptionParser) ParseSubscriptionLink(link string) (option.Outbound, error) {
 	reg := regexp.MustCompile(`^(.*?)(://)(.*?)([@?#].*)?$`)
 	result := reg.FindStringSubmatch(link)
 	if result == nil {
@@ -27,23 +54,23 @@ func ParseSubscriptionLink(link string) (option.Outbound, error) {
 	scheme := result[1]
 	switch scheme {
 	case "tuic":
-		return parseTuicLink(link)
+		return s.parseTuicLink(link)
 	case "trojan":
-		return parseTrojanLink(link)
+		return s.parseTrojanLink(link)
 	case "vless":
-		return parseVLESSLink(link)
+		return s.parseVLESSLink(link)
 	case "hysteria":
-		return parseHysteriaLink(link)
+		return s.parseHysteriaLink(link)
 	case "hy2", "hysteria2":
-		return parseHysteria2Link(link)
+		return s.parseHysteria2Link(link)
 	}
 	result[3], _ = DecodeBase64URLSafe(result[3])
 	link = strings.Join(result[1:], "")
 	switch scheme {
 	case "ss":
-		return parseShadowsocksLink(link)
+		return s.parseShadowsocksLink(link)
 	case "vmess":
-		return parseVMessLink(link)
+		return s.parseVMessLink(link)
 	default:
 		return option.Outbound{}, E.New("unsupported scheme: ", scheme)
 	}
@@ -93,6 +120,24 @@ func StringToType[T any](str string) T {
 	return value
 }
 
+// RU:
+// parseXHTTPRange парсит строку диапазона (например, "100-1000" или "30")
+// и преобразует её в тип Xbadoption.Range для использования в параметрах xhttp транспорта.
+//
+// EN:
+// parseXHTTPRange parses a range string (e.g., "100-1000" or "30") and converts
+// it to the Xbadoption.Range type for use in xhttp transport parameters.
+func parseXHTTPRange(str string) Xbadoption.Range {
+	parts := strings.Split(str, "-")
+	if len(parts) != 2 {
+		from, _ := strconv.ParseInt(parts[0], 10, 32)
+		return Xbadoption.Range{From: int32(from), To: int32(from)}
+	}
+	from, _ := strconv.ParseInt(parts[0], 10, 32)
+	to, _ := strconv.ParseInt(parts[1], 10, 32)
+	return Xbadoption.Range{From: int32(from), To: int32(to)}
+}
+
 func shadowsocksPluginName(plugin string) string {
 	if index := strings.Index(plugin, ";"); index != -1 {
 		return plugin[:index]
@@ -128,7 +173,7 @@ func v2rayTransportWs(host string, path string) option.V2RayWebsocketOptions {
 	return WebsocketOptions
 }
 
-func parseShadowsocksLink(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseShadowsocksLink(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err
@@ -157,7 +202,7 @@ func parseShadowsocksLink(link string) (option.Outbound, error) {
 	return outbound, nil
 }
 
-func parseTuicLink(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseTuicLink(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err
@@ -226,7 +271,7 @@ func parseTuicLink(link string) (option.Outbound, error) {
 	return outbound, nil
 }
 
-func parseVMessLink(link string) (option.Outbound, error) {
+func (p *SubscriptionParser) parseVMessLink(link string) (option.Outbound, error) {
 	var proxy map[string]string
 	reg := regexp.MustCompile(`(\"[^:,]+?\"[ \t]*:[ \t]*)(\d+|true|false)`)
 	s := reg.ReplaceAllString(link, `$1"$2"`)
@@ -372,7 +417,7 @@ func parseVMessLink(link string) (option.Outbound, error) {
 	return outbound, nil
 }
 
-func parseVLESSLink(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseVLESSLink(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err
@@ -421,6 +466,104 @@ func parseVLESSLink(link string) (option.Outbound, error) {
 				}
 				if path, exists := proxy["path"]; exists && path != "" {
 					Transport.HTTPOptions.Path = path
+				}
+			// RU: Парсинг параметров для xhttp
+			// EN: Parsing parameters for xhttp
+			case "xhttp":
+				Transport.Type = C.V2RayTransportTypeXHTTP
+
+				// RU:
+				// Окончательно исправляет неработоспособность xhttp.
+				//
+				// При парсинге транспорта xhttp теперь автоматически устанавливается
+				// ALPN = ["h2", "http/1.1"] по умолчанию. Если в ссылке явно указан
+				// параметр alpn, он перезапишет значение по умолчанию.
+				//
+				// PERF:
+				// Мне кажется это как-то костыльно, и не должно быть так (наверное).
+				// Другие клиенты не обязаны указывать этот параметр.
+				// Возможно я что-то не понимаю, хотя всё равно h3 нам не видать
+				// (т.к h3 это QUIC)
+				// TLSOptions.ALPN = []string{"h2"}
+				//
+				// EN:
+				// It seems a bit clumsy to me, and it probably shouldn't be that way.
+				//
+				// When parsing the xhttp transport, ALPN is now automatically set
+				// to ["h2", "http/1.1"] by default. If the alpn parameter is explicitly
+				// specified in the URL, it will override the default value.
+				//
+				// PERF:
+				// This seems like a workaround to me, and it shouldn't be that way.
+				// Other clients aren't required to specify this parameter.
+				// Maybe I'm missing something, though we won't be seeing h3 anyway (since h3 is QUIC)
+				TLSOptions.ALPN = []string{"h2", "http/1.1"}
+
+				if host, exists := proxy["host"]; exists && host != "" {
+					Transport.XHTTPOptions.Host = host
+				}
+				if path, exists := proxy["path"]; exists && path != "" {
+					Transport.XHTTPOptions.Path = path
+				}
+				if mode, exists := proxy["mode"]; exists && mode != "" {
+					Transport.XHTTPOptions.Mode = mode
+				}
+				// Парсинг extra (base64-encoded JSON) из ссылки внутри подписки.
+				// INFO: DEBUG parser появляется только при начальной инициализации
+				// вашей конфигурации, т.е чтобы повявились json dump логи каждого
+				// outbound'а из вашей подписки необходоимо удалить cache.db файл и
+				// запустить sing-box-extended по новой
+				if extra, exists := proxy["extra"]; exists && extra != "" {
+					decodedExtra, err := DecodeBase64URLSafe(extra)
+					// DEBUG parser
+					// RU: Вывод раскодированного extra
+					// EN: Display the decoded extra
+					s.logger.Debug("decoded extra parameters for outbound \"", linkURL.Fragment, "\": ", string(decodedExtra))
+
+					if err == nil {
+						var extraOptions map[string]interface{}
+						if json.Unmarshal([]byte(decodedExtra), &extraOptions) == nil {
+							if xmux, ok := extraOptions["xmux"].(map[string]interface{}); ok {
+								Transport.XHTTPOptions.Xmux = &option.V2RayXHTTPXmuxOptions{}
+								if val, ok := xmux["cMaxReuseTimes"].(float64); ok {
+									Transport.XHTTPOptions.Xmux.CMaxReuseTimes = Xbadoption.Range{From: int32(val), To: int32(val)}
+								}
+								if val, ok := xmux["maxConcurrency"].(string); ok {
+									Transport.XHTTPOptions.Xmux.MaxConcurrency = parseXHTTPRange(val)
+								}
+								if val, ok := xmux["maxConnections"].(float64); ok {
+									Transport.XHTTPOptions.Xmux.MaxConnections = Xbadoption.Range{From: int32(val), To: int32(val)}
+								}
+								if val, ok := xmux["hKeepAlivePeriod"].(float64); ok {
+									Transport.XHTTPOptions.Xmux.HKeepAlivePeriod = int64(val)
+								}
+								if val, ok := xmux["hMaxRequestTimes"].(string); ok {
+									Transport.XHTTPOptions.Xmux.HMaxRequestTimes = parseXHTTPRange(val)
+								}
+								if val, ok := xmux["hMaxReusableSecs"].(string); ok {
+									Transport.XHTTPOptions.Xmux.HMaxReusableSecs = parseXHTTPRange(val)
+								}
+							}
+							if val, ok := extraOptions["noGRPCHeader"].(bool); ok {
+								Transport.XHTTPOptions.NoGRPCHeader = val
+							}
+							if val, ok := extraOptions["xPaddingBytes"].(string); ok {
+								Transport.XHTTPOptions.XPaddingBytes = parseXHTTPRange(val)
+							}
+							if val, ok := extraOptions["scMaxEachPostBytes"].(float64); ok {
+								Transport.XHTTPOptions.ScMaxEachPostBytes = Xbadoption.Range{From: int32(val), To: int32(val)}
+							}
+							if val, ok := extraOptions["scMinPostsIntervalMs"].(float64); ok {
+								Transport.XHTTPOptions.ScMinPostsIntervalMs = Xbadoption.Range{From: int32(val), To: int32(val)}
+							}
+							if val, ok := extraOptions["scStreamUpServerSecs"].(string); ok {
+								Transport.XHTTPOptions.ScStreamUpServerSecs = parseXHTTPRange(val)
+							}
+							// TODO:
+							// RU: Реализовать парсинг `extra.download`
+							// EN: Implement parsing for `extra.download`
+						}
+					}
 				}
 			case "grpc":
 				Transport.Type = C.V2RayTransportTypeGRPC
@@ -471,10 +614,25 @@ func parseVLESSLink(link string) (option.Outbound, error) {
 		options.TLS = &TLSOptions
 	}
 	outbound.Options = &options
+
+	// DEBUG parser
+	//
+	// RU: Json dump каждых vless:// ссылок в каждой подписке.
+	// INFO: Нужно добавить `import "encoding/json" "fmt"` и убрать
+	// "github.com/sagernet/sing/common/json"
+	//
+	// EN: JSON dump of every vless:// link in each subscription.
+	// INFO: You need to add `import "encoding/json" "fmt"` and remove
+	// `"github.com/sagernet/sing/common/json"`
+	optionsjson, err := json.Marshal(options)
+	if err == nil {
+		s.logger.Debug("final parsed options for outbound \"", linkURL.Fragment, "\": ", string(optionsjson))
+	}
+
 	return outbound, nil
 }
 
-func parseTrojanLink(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseTrojanLink(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err
@@ -551,7 +709,7 @@ func parseTrojanLink(link string) (option.Outbound, error) {
 	return outbound, nil
 }
 
-func parseHysteriaLink(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseHysteriaLink(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err
@@ -610,7 +768,7 @@ func parseHysteriaLink(link string) (option.Outbound, error) {
 	return outbound, nil
 }
 
-func parseHysteria2Link(link string) (option.Outbound, error) {
+func (s *SubscriptionParser) parseHysteria2Link(link string) (option.Outbound, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return option.Outbound{}, err

--- a/provider/parser/parser.go
+++ b/provider/parser/parser.go
@@ -1,0 +1,27 @@
+package parser
+
+import (
+	"context"
+
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+)
+
+var subscriptionParsers = []func(ctx context.Context, content string) ([]option.Outbound, error){
+	ParseBoxSubscription,
+	ParseClashSubscription,
+	ParseSIP008Subscription,
+	ParseRawSubscription,
+}
+
+func ParseSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+	var pErr error
+	for _, parser := range subscriptionParsers {
+		servers, err := parser(ctx, content)
+		if len(servers) > 0 {
+			return servers, nil
+		}
+		pErr = E.Errors(pErr, err)
+	}
+	return nil, E.Cause(pErr, "no servers found")
+}

--- a/provider/parser/raw.go
+++ b/provider/parser/raw.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+)
+
+func ParseRawSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+	if base64Content, err := DecodeBase64URLSafe(content); err == nil {
+		servers, _ := parseRawSubscription(base64Content)
+		if len(servers) > 0 {
+			return servers, err
+		}
+	}
+	return parseRawSubscription(content)
+}
+
+func parseRawSubscription(content string) ([]option.Outbound, error) {
+	var servers []option.Outbound
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	linkList := strings.Split(content, "\n")
+	for _, linkLine := range linkList {
+		server, err := ParseSubscriptionLink(linkLine)
+		if err != nil {
+			continue
+		}
+		servers = append(servers, server)
+	}
+	if len(servers) == 0 {
+		return nil, E.New("no servers found")
+	}
+	return servers, nil
+}
+
+func DecodeBase64URLSafe(content string) (string, error) {
+	s := strings.ReplaceAll(content, " ", "-")
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "+", "-")
+	s = strings.ReplaceAll(s, "=", "")
+	result, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return content, nil
+	}
+	return string(result), nil
+}

--- a/provider/parser/raw.go
+++ b/provider/parser/raw.go
@@ -24,7 +24,7 @@ func parseRawSubscription(content string) ([]option.Outbound, error) {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	linkList := strings.Split(content, "\n")
 	for _, linkLine := range linkList {
-		server, err := ParseSubscriptionLink(linkLine)
+		server, err := defaultParser.ParseSubscriptionLink(linkLine)
 		if err != nil {
 			continue
 		}

--- a/provider/parser/sing_box.go
+++ b/provider/parser/sing_box.go
@@ -1,0 +1,58 @@
+package parser
+
+import (
+	"context"
+
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/common/json/badjson"
+)
+
+type _SingBoxDocument struct {
+	Outbounds []option.Outbound `json:"outbounds"`
+}
+type SingBoxDocument _SingBoxDocument
+
+func (o *SingBoxDocument) UnmarshalJSONContext(ctx context.Context, inputContent []byte) error {
+	var content badjson.JSONObject
+	err := content.UnmarshalJSONContext(ctx, inputContent)
+	if err != nil {
+		return err
+	}
+	outbounds, ok := content.Get("outbounds")
+	if !ok {
+		return E.New("missing outbounds in sing-box configuration")
+	}
+	var outs badjson.JSONArray
+	for i, outbound := range outbounds.(badjson.JSONArray) {
+		typeVal, loaded := outbound.(*badjson.JSONObject).Get("type")
+		if !loaded {
+			return E.New("missing type in outbound[", i, "]")
+		}
+		switch typeVal.(string) {
+		case C.TypeDirect, C.TypeBlock, C.TypeDNS, C.TypeSelector, C.TypeURLTest:
+			continue
+		default:
+			outs = append(outs, outbound)
+		}
+	}
+	content.Put("outbounds", outs)
+	inputContent, err = content.MarshalJSONContext(ctx)
+	if err != nil {
+		return err
+	}
+	return json.UnmarshalContext(ctx, inputContent, (*_SingBoxDocument)(o))
+}
+
+func ParseBoxSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+	options, err := json.UnmarshalExtendedContext[SingBoxDocument](ctx, []byte(content))
+	if err != nil {
+		return nil, err
+	}
+	if len(options.Outbounds) == 0 {
+		return nil, E.New("no servers found")
+	}
+	return options.Outbounds, nil
+}

--- a/provider/parser/sip008.go
+++ b/provider/parser/sip008.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"context"
+
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/json"
+)
+
+type ShadowsocksDocument struct {
+	Version int                         `json:"version"`
+	Servers []ShadowsocksServerDocument `json:"servers"`
+}
+
+type ShadowsocksServerDocument struct {
+	ID         string `json:"id"`
+	Remarks    string `json:"remarks"`
+	Server     string `json:"server"`
+	ServerPort int    `json:"server_port"`
+	Password   string `json:"password"`
+	Method     string `json:"method"`
+	Plugin     string `json:"plugin"`
+	PluginOpts string `json:"plugin_opts"`
+}
+
+func ParseSIP008Subscription(_ context.Context, content string) ([]option.Outbound, error) {
+	var document ShadowsocksDocument
+	err := json.Unmarshal([]byte(content), &document)
+	if err != nil {
+		return nil, E.Cause(err, "parse SIP008 document")
+	}
+
+	var servers []option.Outbound
+	for _, server := range document.Servers {
+		servers = append(servers, option.Outbound{
+			Type: C.TypeShadowsocks,
+			Tag:  server.Remarks,
+			Options: &option.ShadowsocksOutboundOptions{
+				ServerOptions: option.ServerOptions{
+					Server:     server.Server,
+					ServerPort: uint16(server.ServerPort),
+				},
+				Password:      server.Password,
+				Method:        server.Method,
+				Plugin:        server.Plugin,
+				PluginOptions: server.PluginOpts,
+			},
+		})
+	}
+	return servers, nil
+}

--- a/provider/remote/remote.go
+++ b/provider/remote/remote.go
@@ -1,0 +1,337 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/provider"
+	"github.com/sagernet/sing-box/common/interrupt"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/provider/parser"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/json"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/ntp"
+	"github.com/sagernet/sing/service"
+)
+
+func RegisterProvider(registry *provider.Registry) {
+	provider.Register[option.ProviderRemoteOptions](registry, C.ProviderTypeRemote, NewProviderRemote)
+}
+
+var _ adapter.Provider = (*ProviderRemote)(nil)
+
+type ProviderRemote struct {
+	provider.Adapter
+	ctx              context.Context
+	cancel           context.CancelFunc
+	logger           log.ContextLogger
+	outbound         adapter.OutboundManager
+	provider         adapter.ProviderManager
+	cacheFile        adapter.CacheFile
+	dialer           N.Dialer
+	lastEtag         string
+	lastOutOpts      []option.Outbound
+	lastUpdated      time.Time
+	subscriptionInfo adapter.SubscriptionInfo
+	ticker           *time.Ticker
+	updating         atomic.Bool
+
+	url            string
+	userAgent      string
+	downloadDetour string
+	updateInterval time.Duration
+	exclude        *regexp.Regexp
+	include        *regexp.Regexp
+}
+
+func NewProviderRemote(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options option.ProviderRemoteOptions) (adapter.Provider, error) {
+	if options.URL == "" {
+		return nil, E.New("provider URL is required")
+	}
+	updateInterval := time.Duration(options.UpdateInterval)
+	if updateInterval <= 0 {
+		updateInterval = 24 * time.Hour
+	}
+	if updateInterval < time.Minute {
+		updateInterval = time.Minute
+	}
+	var userAgent string
+	if options.UserAgent == "" {
+		userAgent = "sing-box " + C.Version
+	} else {
+		userAgent = options.UserAgent
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	outbound := service.FromContext[adapter.OutboundManager](ctx)
+	logger := logFactory.NewLogger(F.ToString("provider/remote", "[", tag, "]"))
+	updateChan := make(chan struct{})
+	close(updateChan)
+	return &ProviderRemote{
+		Adapter:  provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeRemote, options.HealthCheck),
+		ctx:      ctx,
+		cancel:   cancel,
+		logger:   logger,
+		outbound: outbound,
+		provider: service.FromContext[adapter.ProviderManager](ctx),
+
+		url:            options.URL,
+		userAgent:      userAgent,
+		downloadDetour: options.DownloadDetour,
+		updateInterval: updateInterval,
+		exclude:        (*regexp.Regexp)(options.Exclude),
+		include:        (*regexp.Regexp)(options.Include),
+	}, nil
+}
+
+func (s *ProviderRemote) Start() error {
+	s.cacheFile = service.FromContext[adapter.CacheFile](s.ctx)
+	if s.cacheFile != nil {
+		if saveSub := s.cacheFile.LoadSubscription(s.Tag()); saveSub != nil {
+			content, _ := parser.DecodeBase64URLSafe(string(saveSub.Content))
+			firstLine, others := getFirstLine(content)
+			if info, ok := parseInfo(firstLine); ok {
+				s.subscriptionInfo = info
+				content, _ = parser.DecodeBase64URLSafe(others)
+			}
+			if err := s.updateProviderFromContent(content); err != nil {
+				return E.Cause(err, "restore cached outbound provider")
+			}
+			s.UpdateGroups()
+			s.lastUpdated, s.lastEtag = saveSub.LastUpdated, saveSub.LastEtag
+		}
+	}
+	if s.downloadDetour != "" {
+		outbound, loaded := s.outbound.Outbound(s.downloadDetour)
+		if !loaded {
+			return E.New("detour outbound not found: ", s.downloadDetour)
+		}
+		s.dialer = outbound
+	} else {
+		s.dialer = s.outbound.Default()
+	}
+
+	go s.loopUpdate()
+	return s.Adapter.Start()
+}
+
+func (s *ProviderRemote) Update() error {
+	if s.ticker != nil {
+		s.ticker.Reset(s.updateInterval)
+	}
+	ctx := interrupt.ContextWithIsProviderConnection(s.ctx)
+	return s.fetch(ctx)
+}
+
+func (s *ProviderRemote) UpdatedAt() time.Time {
+	return s.lastUpdated
+}
+
+func (s *ProviderRemote) SubscriptionInfo() adapter.SubscriptionInfo {
+	return s.subscriptionInfo
+}
+
+func (s *ProviderRemote) Close() error {
+	s.cancel()
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+	return common.Close(&s.Adapter)
+}
+
+func (s *ProviderRemote) updateOnce() {
+	ctx := interrupt.ContextWithIsProviderConnection(s.ctx)
+	if err := s.fetch(ctx); err != nil {
+		s.logger.Error("update outbound provider: ", err)
+	}
+}
+
+func (s *ProviderRemote) fetch(ctx context.Context) error {
+	if s.updating.Swap(true) {
+		return E.New("provider is updating")
+	}
+	defer s.updating.Store(false)
+	s.logger.Debug("updating outbound provider ", s.Tag(), " from URL: ", s.url)
+	client := &http.Client{
+		Transport: &http.Transport{
+			ForceAttemptHTTP2:   true,
+			TLSHandshakeTimeout: C.TCPTimeout,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return s.dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+			},
+			TLSClientConfig: &tls.Config{
+				Time:    ntp.TimeFuncFromContext(ctx),
+				RootCAs: adapter.RootPoolFromContext(ctx),
+			},
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, s.url, nil)
+	if err != nil {
+		return err
+	}
+	if s.lastEtag != "" {
+		req.Header.Set("If-None-Match", s.lastEtag)
+	}
+	req.Header.Set("User-Agent", s.userAgent)
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	infoStr := resp.Header.Get("subscription-userinfo")
+	info, hasInfo := parseInfo(infoStr)
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotModified:
+		s.subscriptionInfo = info
+		s.lastUpdated = time.Now()
+		if s.cacheFile != nil {
+			saveSub := s.cacheFile.LoadSubscription(s.Tag())
+			if saveSub != nil {
+				if hasInfo {
+					index := bytes.IndexByte(saveSub.Content, '\n')
+					if index != -1 {
+						saveSub.Content = append([]byte(infoStr+"\n"), saveSub.Content[index+1:]...)
+					}
+				}
+				saveSub.LastUpdated = s.lastUpdated
+				err := s.cacheFile.SaveSubscription(s.Tag(), saveSub)
+				if err != nil {
+					s.logger.Error("save outbound provider cache file: ", err)
+				}
+			}
+		}
+		s.logger.Info("update outbound provider ", s.Tag(), ": not modified")
+		return nil
+	default:
+		return E.New("unexpected status: ", resp.Status)
+	}
+	defer resp.Body.Close()
+	contentRaw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	eTagHeader := resp.Header.Get("Etag")
+	if eTagHeader != "" {
+		s.lastEtag = eTagHeader
+	}
+	content, _ := parser.DecodeBase64URLSafe(string(contentRaw))
+	if !hasInfo {
+		firstLine, others := getFirstLine(content)
+		if info, hasInfo = parseInfo(firstLine); hasInfo {
+			infoStr = firstLine
+			content, _ = parser.DecodeBase64URLSafe(others)
+		}
+	}
+	if err := s.updateProviderFromContent(content); err != nil {
+		return err
+	}
+	s.UpdateGroups()
+	s.subscriptionInfo = info
+	s.lastUpdated = time.Now()
+	if s.cacheFile != nil {
+		content, _ := json.Marshal(option.Options{
+			Outbounds: s.lastOutOpts,
+		})
+		if hasInfo {
+			content = append([]byte(infoStr+"\n"), content...)
+		}
+		err = s.cacheFile.SaveSubscription(s.Tag(), &adapter.SavedBinary{
+			LastUpdated: s.lastUpdated,
+			Content:     content,
+			LastEtag:    s.lastEtag,
+		})
+		if err != nil {
+			s.logger.Error("save outbound provider cache file: ", err)
+		}
+	}
+	s.logger.Info("updated outbound provider ", s.Tag())
+	return nil
+}
+
+func (s *ProviderRemote) loopUpdate() {
+	if time.Since(s.lastUpdated) < s.updateInterval {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(time.Until(s.lastUpdated.Add(s.updateInterval))):
+			s.updateOnce()
+		}
+	} else {
+		s.updateOnce()
+	}
+	s.ticker = time.NewTicker(s.updateInterval)
+	for {
+		runtime.GC()
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-s.ticker.C:
+			s.updateOnce()
+		}
+	}
+}
+
+func (s *ProviderRemote) updateProviderFromContent(content string) error {
+	outboundOpts, err := parser.ParseSubscription(s.ctx, content)
+	if err != nil {
+		return err
+	}
+	outboundOpts = common.Filter(outboundOpts, func(it option.Outbound) bool {
+		return (s.exclude == nil || !s.exclude.MatchString(it.Tag)) && (s.include == nil || s.include.MatchString(it.Tag))
+	})
+	s.UpdateOutbounds(s.lastOutOpts, outboundOpts)
+	s.lastOutOpts = outboundOpts
+	return nil
+}
+
+func getFirstLine(content string) (string, string) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 1 {
+		return lines[0], ""
+	}
+	others := strings.Join(lines[1:], "\n")
+	return lines[0], others
+}
+
+func parseInfo(infoStr string) (adapter.SubscriptionInfo, bool) {
+	info := adapter.SubscriptionInfo{}
+	if infoStr == "" {
+		return info, false
+	}
+	reg := regexp.MustCompile(`(upload|download|total|expire)[\s\t]*=[\s\t]*(-?\d*);?`)
+	matches := reg.FindAllStringSubmatch(infoStr, 4)
+	if len(matches) == 0 {
+		return info, false
+	}
+	for _, match := range matches {
+		key, value := match[1], match[2]
+		switch key {
+		case "upload":
+			info.Upload = parser.StringToType[int64](value)
+		case "download":
+			info.Download = parser.StringToType[int64](value)
+		case "total":
+			info.Total = parser.StringToType[int64](value)
+		case "expire":
+			info.Expire = parser.StringToType[int64](value)
+		default:
+			return info, false
+		}
+	}
+	return info, true
+}


### PR DESCRIPTION
The source code was taken from [this author](https://github.com/nekolsd/sing-box/commit/238381ffa4bc397d664e16df2edf87f1d64fac17) with my edits to successfully compile sing-box-extended

Problems that need to be solved

1. ~xhttp+tls and xhttp+reality from the subscription (both remote and local) are added but do not work, they are not pinged from an external web panel such as [metacubexd](https://github.com/MetaCubeX/metacubexd) or [zashboard](https://github.com/Zephyruso/zashboard). If anyone has any solutions, please help with this (I know the Go language only a little)~ [Fixed](https://github.com/shtorm-7/sing-box-extended/pull/36/changes/cf020c5993f0fab821aa73f88a041e44c28eac82), but it's still WIP

Example of proxy `providers` configuration (Local and Remote)

```json
   "providers": [
       {
           "type": "local",
           "tag": "Subscription (Local)",
           "path": "provider.txt",
           "health_check": {
               "enabled": true,
               "url": "https://www.gstatic.com/generate_204",
               "interval": "10m",
               "timeout": "5s"
           },
           "override_dialer": {}
       },
       {
           "type": "remote",
           "tag": "Subscription (Remote)",
           "health_check": {
               "enabled": true,
               "url": "https://www.gstatic.com/generate_204",
               "interval": "10m",
               "timeout": "5s"
           },
           "url": "SUB_URL",
           "exclude": "Traffic|Expire",
           "update_interval": "24h",
           "override_dialer": {}
       }
   ],
```

Example of links with xhttp+reality and xhttp+tls from a file `provider.txt` 

```txt
vless://${UUID}@test.domain.com:443?security=reality&type=xhttp&headerType=&path=%2Fspeedtest&host=test.domain.com&flow=&mode=auto&sni=test.domain.com&fp=firefox&pbk=${PBK}&sid=${SID}#01-XHTTP-REALITY

vless://${UUID}@test.domain.com:443?security=tls&type=xhttp&headerType=&path=%2Fspeedtest&host=test.domain.com&flow=&mode=auto&sni=test.domain.com&fp=chrome&alpn=h2%2Chttp%2F1.1#01-XHTTP-TLS
```

The extracted xhttp+reality and xhttp+tls links from the subscription were obtained by this command

```sh
d64() { [[ $# == 1 ]] && base64 --decode <<<"$1" || base64 --decode; echo }
curl -A "v2rayn" SUB_URL | d64
```