### PR TITLE
xhttp: fix padding_obfs rejecting valid header/query keys

### DIFF
--- a/transport/v2rayxhttp/xpadding.go
+++ b/transport/v2rayxhttp/xpadding.go
@@ -172,11 +172,18 @@ func ApplyXPaddingToHeader(h http.Header, config XPaddingConfig) {
 	paddingValue := GeneratePadding(config.Method, config.Length)
 	switch p := config.Placement; p.Placement {
 	case option.PlacementHeader:
-		h.Set(p.Header, paddingValue)
+		if p.Header != "" {
+			h.Set(p.Header, paddingValue)
+		}
 	case option.PlacementQueryInHeader:
+		if p.Header == "" || p.Key == "" {
+			return
+		}
 		u, err := url.Parse(p.RawURL)
 		if err != nil || u == nil {
-			return
+			// No source URL (e.g., server response side): fall back to a
+			// synthetic relative URL so the wire shape stays "?key=value".
+			u = &url.URL{Path: "/"}
 		}
 		u.RawQuery = p.Key + "=" + paddingValue
 		h.Set(p.Header, u.String())
@@ -205,16 +212,79 @@ func ApplyXPaddingToRequest(req *http.Request, config XPaddingConfig) {
 }
 
 func ApplyXPaddingToResponse(writer http.ResponseWriter, config XPaddingConfig) {
-	placement := config.Placement.Placement
-	if placement == option.PlacementHeader || placement == option.PlacementQueryInHeader {
-		ApplyXPaddingToHeader(writer.Header(), config)
+	if writer == nil {
 		return
 	}
-	paddingValue := GeneratePadding(config.Method, config.Length)
+	placement := config.Placement.Placement
+	switch placement {
+	case option.PlacementHeader, option.PlacementQueryInHeader:
+		ApplyXPaddingToHeader(writer.Header(), config)
+	case option.PlacementCookie:
+		paddingValue := GeneratePadding(config.Method, config.Length)
+		ApplyPaddingToResponseCookie(writer, config.Placement.Key, paddingValue)
+	case option.PlacementQuery:
+		// Query placement makes no sense for a response (no request URL).
+		// Fall back to a header so the response still carries padding for
+		// traffic-shape symmetry.
+		paddingValue := GeneratePadding(config.Method, config.Length)
+		headerName := config.Placement.Header
+		if headerName == "" {
+			headerName = "X-Padding"
+		}
+		writer.Header().Set(headerName, paddingValue)
+	}
+}
+
+// extractFromPlacement reads the padding value from a single placement only.
+// Returns ("", "") if not found there.
+func extractFromPlacement(req *http.Request, placement, key, header string) (string, string) {
 	switch placement {
 	case option.PlacementCookie:
-		ApplyPaddingToResponseCookie(writer, config.Placement.Key, paddingValue)
+		if key == "" {
+			return "", ""
+		}
+		cookie, err := req.Cookie(key)
+		if err != nil || cookie == nil || cookie.Value == "" {
+			return "", ""
+		}
+		return cookie.Value, option.PlacementCookie + ", key=" + key
+	case option.PlacementHeader:
+		if header == "" {
+			return "", ""
+		}
+		v := req.Header.Get(header)
+		if v == "" {
+			return "", ""
+		}
+		return v, option.PlacementHeader + "=" + header
+	case option.PlacementQueryInHeader:
+		if header == "" || key == "" {
+			return "", ""
+		}
+		hv := req.Header.Get(header)
+		if hv == "" {
+			return "", ""
+		}
+		parsedURL, err := url.Parse(hv)
+		if err != nil || parsedURL == nil {
+			return "", ""
+		}
+		v := parsedURL.Query().Get(key)
+		if v == "" {
+			return "", ""
+		}
+		return v, option.PlacementQueryInHeader + "=" + header + ", key=" + key
+	case option.PlacementQuery:
+		if key == "" || req.URL == nil {
+			return "", ""
+		}
+		v := req.URL.Query().Get(key)
+		if v == "" {
+			return "", ""
+		}
+		return v, option.PlacementQuery + ", key=" + key
 	}
+	return "", ""
 }
 
 func ExtractXPaddingFromRequest(options *option.V2RayXHTTPBaseOptions, req *http.Request, obfsMode bool) (string, string) {
@@ -222,44 +292,62 @@ func ExtractXPaddingFromRequest(options *option.V2RayXHTTPBaseOptions, req *http
 		return "", ""
 	}
 	if !obfsMode {
+		// Non-obfs (legacy) mode: padding is in Referer query, or URL query
+		// if no Referer is present. Never fall through into the obfs paths.
 		referrer := req.Header.Get("Referer")
 		if referrer != "" {
-			if referrerURL, err := url.Parse(referrer); err == nil {
-				paddingValue := referrerURL.Query().Get("x_padding")
-				paddingPlacement := option.PlacementQueryInHeader + "=Referer, key=x_padding"
-				return paddingValue, paddingPlacement
+			referrerURL, err := url.Parse(referrer)
+			if err != nil {
+				return "", option.PlacementQueryInHeader + "=Referer (unparseable)"
 			}
-		} else {
-			paddingValue := req.URL.Query().Get("x_padding")
-			return paddingValue, option.PlacementQuery + ", key=x_padding"
+			return referrerURL.Query().Get("x_padding"), option.PlacementQueryInHeader + "=Referer, key=x_padding"
 		}
+		if req.URL != nil {
+			return req.URL.Query().Get("x_padding"), option.PlacementQuery + ", key=x_padding"
+		}
+		return "", ""
 	}
+
+	// obfs mode: read padding from the configured placement.
 	key := options.XPaddingKey
 	header := options.XPaddingHeader
-	if cookie, err := req.Cookie(key); err == nil {
-		if cookie != nil && cookie.Value != "" {
-			paddingValue := cookie.Value
-			paddingPlacement := option.PlacementCookie + ", key=" + key
-			return paddingValue, paddingPlacement
+	placement := options.XPaddingPlacement
+
+	if v, p := extractFromPlacement(req, placement, key, header); v != "" {
+		return v, p
+	}
+
+	// Fallback: probe the other placements in case a peer using a different
+	// configuration (e.g. an older client) is talking to this server. This
+	// preserves interoperability without weakening the configured path.
+	fallbacks := []string{
+		option.PlacementHeader,
+		option.PlacementQueryInHeader,
+		option.PlacementCookie,
+		option.PlacementQuery,
+	}
+	for _, fp := range fallbacks {
+		if fp == placement {
+			continue
+		}
+		if v, p := extractFromPlacement(req, fp, key, header); v != "" {
+			return v, p
 		}
 	}
-	headerValue := req.Header.Get(header)
-	if headerValue != "" {
-		if options.XPaddingPlacement == option.PlacementHeader {
-			paddingPlacement := option.PlacementHeader + "=" + header
-			return headerValue, paddingPlacement
-		}
 
-		if parsedURL, err := url.Parse(headerValue); err == nil {
-			paddingPlacement := option.PlacementQueryInHeader + "=" + header + ", key=" + key
-
-			return parsedURL.Query().Get(key), paddingPlacement
+	// Final fallback: legacy Referer + x_padding (used by the non-obfs client
+	// path and historical sing-box releases).
+	if referrer := req.Header.Get("Referer"); referrer != "" {
+		if referrerURL, err := url.Parse(referrer); err == nil {
+			if v := referrerURL.Query().Get("x_padding"); v != "" {
+				return v, option.PlacementQueryInHeader + "=Referer, key=x_padding"
+			}
 		}
 	}
-	queryValue := req.URL.Query().Get(key)
-	if queryValue != "" {
-		paddingPlacement := option.PlacementQuery + ", key=" + key
-		return queryValue, paddingPlacement
+	if req.URL != nil {
+		if v := req.URL.Query().Get("x_padding"); v != "" {
+			return v, option.PlacementQuery + ", key=x_padding"
+		}
 	}
 	return "", ""
 }

--- a/transport/v2rayxhttp/xpadding_e2e_test.go
+++ b/transport/v2rayxhttp/xpadding_e2e_test.go
@@ -1,0 +1,253 @@
+package xhttp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	Xbadoption "github.com/sagernet/sing-box/common/xray/json/badoption"
+	"github.com/sagernet/sing-box/option"
+)
+
+func opts(placement, key, header, method string) *option.V2RayXHTTPBaseOptions {
+	return &option.V2RayXHTTPBaseOptions{
+		XPaddingBytes:     Xbadoption.Range{From: 100, To: 1000},
+		XPaddingPlacement: placement,
+		XPaddingKey:       key,
+		XPaddingHeader:    header,
+		XPaddingMethod:    method,
+	}
+}
+
+// e2e: client sends real HTTP request via net/http test server, server extracts padding.
+func runE2E(t *testing.T, o *option.V2RayXHTTPBaseOptions, obfsMode bool) (string, string) {
+	t.Helper()
+
+	resultVal := ""
+	resultPlace := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resultVal, resultPlace = ExtractXPaddingFromRequest(o, r, obfsMode)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/xhttp/")
+	req, _ := http.NewRequest("POST", u.String(), strings.NewReader("hello"))
+
+	length := 250
+	cfg := XPaddingConfig{Length: length}
+	if obfsMode {
+		cfg.Placement = XPaddingPlacement{
+			Placement: o.XPaddingPlacement,
+			Key:       o.XPaddingKey,
+			Header:    o.XPaddingHeader,
+			RawURL:    req.URL.String(),
+		}
+		cfg.Method = PaddingMethod(o.XPaddingMethod)
+	} else {
+		cfg.Placement = XPaddingPlacement{
+			Placement: option.PlacementQueryInHeader,
+			Key:       "x_padding",
+			Header:    "Referer",
+			RawURL:    req.URL.String(),
+		}
+	}
+	ApplyXPaddingToRequest(req, cfg)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	return resultVal, resultPlace
+}
+
+func TestE2E_ObfsHeaderXPadding(t *testing.T) {
+	o := opts("header", "x_padding", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsHeaderCustom(t *testing.T) {
+	o := opts("header", "mykey", "X-My-Pad", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsCookie(t *testing.T) {
+	o := opts("cookie", "x_padding", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsCookieCustomKey(t *testing.T) {
+	o := opts("cookie", "mypad", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsQuery(t *testing.T) {
+	o := opts("query", "x_padding", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsQueryCustomKey(t *testing.T) {
+	o := opts("query", "mypad", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsQueryInHeader(t *testing.T) {
+	o := opts("queryInHeader", "x_padding", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsQueryInHeaderReferer(t *testing.T) {
+	o := opts("queryInHeader", "x_padding", "Referer", "repeat-x")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_NoObfs(t *testing.T) {
+	o := opts("queryInHeader", "x_padding", "X-Padding", "repeat-x")
+	val, place := runE2E(t, o, false)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsTokenish(t *testing.T) {
+	o := opts("header", "x_padding", "X-Padding", "tokenish")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "tokenish") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestE2E_ObfsTokenishQueryInHeader(t *testing.T) {
+	o := opts("queryInHeader", "x_padding", "X-Padding", "tokenish")
+	val, place := runE2E(t, o, true)
+	t.Logf("placement=%s val-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "tokenish") {
+		t.Fatalf("not valid: place=%s len=%d", place, len(val))
+	}
+}
+
+// Cross-config: server expects header placement, but client (e.g. legacy
+// sing-box) is still sending Referer + x_padding. The fallback path should
+// allow the server to accept the request.
+func TestE2E_ObfsServerWithLegacyClient(t *testing.T) {
+	srvOpts := opts("header", "x_padding", "X-Padding", "repeat-x")
+
+	resultVal := ""
+	resultPlace := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resultVal, resultPlace = ExtractXPaddingFromRequest(srvOpts, r, true)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/xhttp/")
+	req, _ := http.NewRequest("POST", u.String(), strings.NewReader("hello"))
+
+	// Legacy client behaviour: Referer-based padding.
+	cfg := XPaddingConfig{Length: 250}
+	cfg.Placement = XPaddingPlacement{
+		Placement: option.PlacementQueryInHeader,
+		Key:       "x_padding",
+		Header:    "Referer",
+		RawURL:    req.URL.String(),
+	}
+	ApplyXPaddingToRequest(req, cfg)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	t.Logf("placement=%s val-len=%d", resultPlace, len(resultVal))
+	if !IsPaddingValid(srvOpts, resultVal, 100, 1000, "repeat-x") {
+		t.Fatalf("not valid: place=%s len=%d", resultPlace, len(resultVal))
+	}
+}
+
+// A stale cookie sharing the configured key must not shadow the real padding
+// that lives in the configured placement (here: a header).
+func TestE2E_StaleCookieDoesNotMaskHeader(t *testing.T) {
+	srvOpts := opts("header", "x_padding", "X-Padding", "repeat-x")
+
+	resultVal := ""
+	resultPlace := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resultVal, resultPlace = ExtractXPaddingFromRequest(srvOpts, r, true)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL + "/xhttp/")
+	req, _ := http.NewRequest("POST", u.String(), strings.NewReader("hello"))
+
+	// Real padding in the header (as the configuration expects).
+	cfg := XPaddingConfig{Length: 250}
+	cfg.Placement = XPaddingPlacement{
+		Placement: "header",
+		Key:       "x_padding",
+		Header:    "X-Padding",
+		RawURL:    req.URL.String(),
+	}
+	cfg.Method = "repeat-x"
+	ApplyXPaddingToRequest(req, cfg)
+
+	// Add a stale cookie with the same key but a too-short value.
+	req.AddCookie(&http.Cookie{Name: "x_padding", Value: "short"})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	t.Logf("placement=%s val-len=%d", resultPlace, len(resultVal))
+	if !IsPaddingValid(srvOpts, resultVal, 100, 1000, "repeat-x") {
+		t.Fatalf("stale cookie should not be picked up: place=%s len=%d", resultPlace, len(resultVal))
+	}
+	if !strings.Contains(resultPlace, "header") {
+		t.Fatalf("expected the configured header placement to win, got: %s", resultPlace)
+	}
+}

--- a/transport/v2rayxhttp/xpadding_test.go
+++ b/transport/v2rayxhttp/xpadding_test.go
@@ -1,0 +1,150 @@
+package xhttp
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/sagernet/sing-box/option"
+	Xbadoption "github.com/sagernet/sing-box/common/xray/json/badoption"
+)
+
+func newReq(t *testing.T, raw string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func baseOpts(placement, key, header, method string) *option.V2RayXHTTPBaseOptions {
+	return &option.V2RayXHTTPBaseOptions{
+		XPaddingBytes:     Xbadoption.Range{From: 100, To: 1000},
+		XPaddingPlacement: placement,
+		XPaddingKey:       key,
+		XPaddingHeader:    header,
+		XPaddingMethod:    method,
+	}
+}
+
+// roundTrip simulates client building a request then server extracting padding.
+func roundTrip(t *testing.T, opts *option.V2RayXHTTPBaseOptions, obfsMode bool) (string, string, *http.Request) {
+	t.Helper()
+	req := newReq(t, "https://example.com/xhttp")
+
+	length := 200
+	cfg := XPaddingConfig{Length: length}
+	if obfsMode {
+		cfg.Placement = XPaddingPlacement{
+			Placement: opts.XPaddingPlacement,
+			Key:       opts.XPaddingKey,
+			Header:    opts.XPaddingHeader,
+			RawURL:    req.URL.String(),
+		}
+		cfg.Method = PaddingMethod(opts.XPaddingMethod)
+	} else {
+		cfg.Placement = XPaddingPlacement{
+			Placement: option.PlacementQueryInHeader,
+			Key:       "x_padding",
+			Header:    "Referer",
+			RawURL:    req.URL.String(),
+		}
+	}
+	ApplyXPaddingToRequest(req, cfg)
+
+	val, place := ExtractXPaddingFromRequest(opts, req, obfsMode)
+	return val, place, req
+}
+
+func TestObfsModeQueryInHeaderDefault(t *testing.T) {
+	o := baseOpts("queryInHeader", "x_padding", "X-Padding", "repeat-x")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestObfsModeQueryInHeaderReferer(t *testing.T) {
+	o := baseOpts("queryInHeader", "x_padding", "Referer", "repeat-x")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestObfsModeHeader(t *testing.T) {
+	o := baseOpts("header", "x_padding", "X-Padding", "repeat-x")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestObfsModeCookie(t *testing.T) {
+	o := baseOpts("cookie", "x_padding", "X-Padding", "repeat-x")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestObfsModeQuery(t *testing.T) {
+	o := baseOpts("query", "x_padding", "X-Padding", "repeat-x")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestObfsModeTokenish(t *testing.T) {
+	o := baseOpts("header", "x_padding", "X-Padding", "tokenish")
+	val, place, _ := roundTrip(t, o, true)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "tokenish") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+func TestNoObfsReferer(t *testing.T) {
+	o := baseOpts("queryInHeader", "x_padding", "X-Padding", "repeat-x")
+	val, place, _ := roundTrip(t, o, false)
+	t.Logf("placement=%s value-len=%d", place, len(val))
+	if !IsPaddingValid(o, val, 100, 1000, "repeat-x") {
+		t.Fatalf("validation failed: place=%s len=%d", place, len(val))
+	}
+}
+
+// Edge case: when obfs mode is OFF on the SERVER but ON on the CLIENT.
+// (Could happen if user only configures one side)
+func TestServerNoObfsClientObfsHeader(t *testing.T) {
+	o := baseOpts("queryInHeader", "x_padding", "X-Padding", "repeat-x")
+
+	// Client side (obfs mode ON, placement=header)
+	req := newReq(t, "https://example.com/xhttp")
+	cfg := XPaddingConfig{Length: 200}
+	cfg.Placement = XPaddingPlacement{
+		Placement: "header",
+		Key:       "x_padding",
+		Header:    "X-Padding",
+		RawURL:    req.URL.String(),
+	}
+	cfg.Method = "repeat-x"
+	ApplyXPaddingToRequest(req, cfg)
+
+	// Server side (obfs mode OFF)
+	val, place := ExtractXPaddingFromRequest(o, req, false)
+	t.Logf("server (no obfs) extraction: placement=%s value-len=%d", place, len(val))
+}
+
+// Test what happens if URL parse of header succeeds but the value is not actually a URL.
+func TestParseNonURLValue(t *testing.T) {
+	rawValue := "XXXXXXXXXXXXXXXXXXXXXXXXX"
+	parsed, err := url.Parse(rawValue)
+	t.Logf("parse %q -> err=%v query[x_padding]=%q", rawValue, err, parsed.Query().Get("x_padding"))
+}


### PR DESCRIPTION
### Problem
In obfs mode, `ExtractXPaddingFromRequest` unconditionally probed `req.Cookie(key)` before honoring the configured placement. A stale or unrelated cookie sharing the configured key would shadow the real padding sitting in the header/query, so the server returned 400 on every request except the default queryInHeader + Referer + x_padding combo (which never sets a cookie). It also fully ignored legacy Referer-based padding whenever obfs_mode was true, rejecting any non-obfs client.

### Fix
- Check the configured placement first, strictly.
- Fall back to the other placements for cross-config interop.
- Final fallback to legacy Referer + x_padding for older peers.
- ApplyXPaddingToResponse no longer silently drops padding when placement=query.
- ApplyXPaddingToHeader no longer bails out on empty RawURL for placement=queryInHeader on the response side.
- The non-obfs branch no longer falls through into obfs paths when Referer fails to parse.

### Tests
Added xpadding_test.go and xpadding_e2e_test.go covering all four placements, tokenish vs repeat-x padding, and the two regression cases. go test ./transport/v2rayxhttp/ passes on current extended HEAD.