### PR TITLE
Fingerprinting fix

### DIFF
--- a/common/tls/reality_client.go
+++ b/common/tls/reality_client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/sagernet/sing-box/adapter"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/debug"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/logger"
@@ -130,22 +129,24 @@ func (e *RealityClientConfig) ClientHandshake(ctx context.Context, conn net.Conn
 	if err != nil {
 		return nil, err
 	}
-	for _, extension := range uConn.Extensions {
-		if ce, ok := extension.(*utls.SupportedCurvesExtension); ok {
-			ce.Curves = common.Filter(ce.Curves, func(curveID utls.CurveID) bool {
-				return curveID != utls.X25519MLKEM768
-			})
+	/*
+		for _, extension := range uConn.Extensions {
+			if ce, ok := extension.(*utls.SupportedCurvesExtension); ok {
+				ce.Curves = common.Filter(ce.Curves, func(curveID utls.CurveID) bool {
+					return curveID != utls.X25519MLKEM768
+				})
+			}
+			if ks, ok := extension.(*utls.KeyShareExtension); ok {
+				ks.KeyShares = common.Filter(ks.KeyShares, func(share utls.KeyShare) bool {
+					return share.Group != utls.X25519MLKEM768
+				})
+			}
 		}
-		if ks, ok := extension.(*utls.KeyShareExtension); ok {
-			ks.KeyShares = common.Filter(ks.KeyShares, func(share utls.KeyShare) bool {
-				return share.Group != utls.X25519MLKEM768
-			})
+		err = uConn.BuildHandshakeState()
+		if err != nil {
+			return nil, err
 		}
-	}
-	err = uConn.BuildHandshakeState()
-	if err != nil {
-		return nil, err
-	}
+	*/
 
 	if len(uConfig.NextProtos) > 0 {
 		for _, extension := range uConn.Extensions {

--- a/common/tls/utls_client.go
+++ b/common/tls/utls_client.go
@@ -288,9 +288,9 @@ func init() {
 	modernFingerprints := []utls.ClientHelloID{
 		utls.HelloChrome_Auto,
 		utls.HelloFirefox_Auto,
-		utls.HelloEdge_Auto,
 		utls.HelloSafari_Auto,
-		utls.HelloIOS_Auto,
+		utls.HelloAndroid_OkHttp_Auto,
+		utls.HelloChrome_141_TA,
 	}
 	randomFingerprint = modernFingerprints[rand.Intn(len(modernFingerprints))]
 
@@ -308,6 +308,10 @@ func uTLSClientHelloID(name string) (utls.ClientHelloID, error) {
 		fallthrough
 	case "chrome", "":
 		return utls.HelloChrome_Auto, nil
+	case "chrome_ta":
+		return utls.HelloChrome_141_TA, nil
+	case "chrome_ta_pqs":
+		return utls.HelloChrome_144_TA_PQS, nil
 	case "firefox":
 		return utls.HelloFirefox_Auto, nil
 	case "edge":
@@ -321,7 +325,7 @@ func uTLSClientHelloID(name string) (utls.ClientHelloID, error) {
 	case "ios":
 		return utls.HelloIOS_Auto, nil
 	case "android":
-		return utls.HelloAndroid_11_OkHttp, nil
+		return utls.HelloAndroid_OkHttp_Auto, nil
 	case "random":
 		return randomFingerprint, nil
 	case "randomized":

--- a/go.mod
+++ b/go.mod
@@ -236,3 +236,5 @@ replace github.com/Diniboy1123/connect-ip-go => github.com/shtorm-7/connect-ip-g
 replace github.com/shtorm-7/go-cache/v2 => github.com/shtorm-7/go-cache/v2 v2.1.0-extended-1.1.0
 
 replace github.com/sagernet/sing => github.com/shtorm-7/sing v0.8.10-extended-1.1.0
+
+replace github.com/metacubex/utls => github.com/re7gog/utls v1.9.0-gog

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,6 @@ github.com/mdlayher/netlink v1.9.0 h1:G8+GLq2x3v4D4MVIqDdNUhTUC7TKiCy/6MDkmItfKc
 github.com/mdlayher/netlink v1.9.0/go.mod h1:YBnl5BXsCoRuwBjKKlZ+aYmEoq0r12FDA/3JC+94KDg=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/metacubex/utls v1.8.4 h1:HmL9nUApDdWSkgUyodfwF6hSjtiwCGGdyhaSpEejKpg=
-github.com/metacubex/utls v1.8.4/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
 github.com/mholt/acmez/v3 v3.1.6 h1:eGVQNObP0pBN4sxqrXeg7MYqTOWyoiYpQqITVWlrevk=
 github.com/mholt/acmez/v3 v3.1.6/go.mod h1:5nTPosTGosLxF3+LU4ygbgMRFDhbAVpqMI4+a4aHLBY=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
@@ -268,6 +266,8 @@ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/re7gog/utls v1.9.0-gog h1:g+9vd42Gfeh9YxhrAT/zGHtWks/d4K9VOSEz4+dLHds=
+github.com/re7gog/utls v1.9.0-gog/go.mod h1:LEKrR8PMLFXVCa77RxGzb84gRZQEBo6yuEu+uSGzy6k=
 github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
 github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.26.1
+go 1.26.4
 
 require github.com/sagernet/sing-box v0.0.0
 


### PR DESCRIPTION
По сути фикс всех проблем фингерпринтинга reality:
Chrome: новые экспериментальные версии.
Firefox: исправление несоответствия того что удалили один chirpher + расширения в нормальном режиме импользуемые.
Edge: на самом деле устаревший отпечаток, современный это 1:1 chrome.
Android: новая версия на основе android 16 вместо 11.
Является солянкой из висящих pull request-ов у официального utls, потому что непонятно где разраб.
Проверялось через JA4 сумму в Wireshark.
Рекомендую еще самостоятельно протестировать конечно.