### PR TITLE
Make masque TLS SNI configurable via server_name

### DIFF
--- a/examples/masque/client.json
+++ b/examples/masque/client.json
@@ -40,6 +40,7 @@
       "udp_initial_packet_size": 0,
       "reconnect_delay": "5s",
       "tls": { // TLS fields for HTTP2
+        "server_name": "", // SNI; empty = default "consumer-masque.cloudflareclient.com"
         "insecure": false,
         "cipher_suites": [],
         "curve_preferences": [],

--- a/option/masque.go
+++ b/option/masque.go
@@ -22,6 +22,7 @@ type MASQUEOutboundOptions struct {
 }
 
 type MASQUEOutboundTLSOptions struct {
+	ServerName            string                              `json:"server_name,omitempty"`
 	Insecure              bool                                `json:"insecure,omitempty"`
 	CipherSuites          badoption.Listable[string]          `json:"cipher_suites,omitempty"`
 	CurvePreferences      badoption.Listable[CurvePreference] `json:"curve_preferences,omitempty"`

--- a/protocol/masque/outbound.go
+++ b/protocol/masque/outbound.go
@@ -100,7 +100,11 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 			logger.ErrorContext(ctx, E.New("failed to generate cert: ", err))
 			return
 		}
-		tlsConfig, err := tls.NewMASQUEClient(ctx, logger, "consumer-masque.cloudflareclient.com", cert, privKey, peerPubKey, common.PtrValueOrDefault(options.TLS))
+		serverName := cloudflare.ConnectSNI
+		if options.TLS != nil && options.TLS.ServerName != "" {
+			serverName = options.TLS.ServerName
+		}
+		tlsConfig, err := tls.NewMASQUEClient(ctx, logger, serverName, cert, privKey, peerPubKey, common.PtrValueOrDefault(options.TLS))
 		if err != nil {
 			logger.ErrorContext(ctx, E.New("failed to prepare TLS config: ", err))
 			return


### PR DESCRIPTION
Ранее в исходящих запросах MASQUE значение SNI для TLS было жестко задано как consumer-masque.cloudflareclient.com. Добавл поле server_name в параметры исходящих запросов TLS MASQUE. Если оно пустое, используется существующее значение по умолчанию (cloudflare.ConnectSNI), поэтому существующие конфигурации останутся без изменений.