### PR TITLE
Add warp get/gen commands to the tools

### DIFF
--- a/cmd/sing-box/cmd_tools.go
+++ b/cmd/sing-box/cmd_tools.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 
-	"github.com/sagernet/sing-box"
+	box "github.com/sagernet/sing-box"
 	E "github.com/sagernet/sing/common/exceptions"
 	N "github.com/sagernet/sing/common/network"
 
@@ -23,22 +24,25 @@ func init() {
 	mainCommand.AddCommand(commandTools)
 }
 
-func createPreStartedClient() (*box.Box, error) {
+func createPreStartedClient() (*box.Box, context.CancelFunc, error) {
 	options, err := readConfigAndMerge()
 	if err != nil {
 		if !(errors.Is(err, os.ErrNotExist) && len(configDirectories) == 0 && len(configPaths) == 1) || configPaths[0] != "config.json" {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	instance, err := box.New(box.Options{Context: globalCtx, Options: options})
+	ctx, cancel := context.WithCancel(globalCtx)
+	instance, err := box.New(box.Options{Context: ctx, Options: options})
 	if err != nil {
-		return nil, E.Cause(err, "create service")
+		cancel()
+		return nil, nil, E.Cause(err, "create service")
 	}
 	err = instance.PreStart()
 	if err != nil {
-		return nil, E.Cause(err, "start service")
+		cancel()
+		return nil, nil, E.Cause(err, "start service")
 	}
-	return instance, nil
+	return instance, cancel, nil
 }
 
 func createDialer(instance *box.Box, outboundTag string) (N.Dialer, error) {

--- a/cmd/sing-box/cmd_tools_connect.go
+++ b/cmd/sing-box/cmd_tools_connect.go
@@ -40,11 +40,14 @@ func connect(address string) error {
 	default:
 		return E.Cause(N.ErrUnknownNetwork, commandConnectFlagNetwork)
 	}
-	instance, err := createPreStartedClient()
+	instance, cancel, err := createPreStartedClient()
 	if err != nil {
 		return err
 	}
-	defer instance.Close()
+	defer func() {
+		cancel()
+		instance.Close()
+	}()
 	dialer, err := createDialer(instance, commandToolsFlagOutbound)
 	if err != nil {
 		return err

--- a/cmd/sing-box/cmd_tools_fetch.go
+++ b/cmd/sing-box/cmd_tools_fetch.go
@@ -40,11 +40,14 @@ var (
 )
 
 func fetch(args []string) error {
-	instance, err := createPreStartedClient()
+	instance, cancel, err := createPreStartedClient()
 	if err != nil {
 		return err
 	}
-	defer instance.Close()
+	defer func() {
+		cancel()
+		instance.Close()
+	}()
 	httpClient = &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/cmd/sing-box/cmd_tools_synctime.go
+++ b/cmd/sing-box/cmd_tools_synctime.go
@@ -39,15 +39,18 @@ func init() {
 }
 
 func syncTime() error {
-	instance, err := createPreStartedClient()
+	instance, cancel, err := createPreStartedClient()
 	if err != nil {
 		return err
 	}
+	defer func() {
+		cancel()
+		instance.Close()
+	}()
 	dialer, err := createDialer(instance, commandToolsFlagOutbound)
 	if err != nil {
 		return err
 	}
-	defer instance.Close()
 	serverAddress := M.ParseSocksaddr(commandSyncTimeFlagServer)
 	if serverAddress.Port == 0 {
 		serverAddress.Port = 123

--- a/cmd/sing-box/cmd_tools_warp.go
+++ b/cmd/sing-box/cmd_tools_warp.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/spf13/cobra"
+)
+
+var commandToolsWarp = &cobra.Command{
+	Use:   "warp",
+	Short: "Manage WARP/MASQUE accounts",
+}
+
+func init() {
+	commandTools.AddCommand(commandToolsWarp)
+}
+
+// collectWarpEntries maps each WARP/MASQUE outbound/endpoint tag declared in the
+// configuration to its type (C.TypeWARP or C.TypeMASQUE).
+func collectWarpEntries(options *option.Options) map[string]string {
+	entries := make(map[string]string)
+	for _, outbound := range options.Outbounds {
+		if outbound.Type == C.TypeMASQUE {
+			entries[outbound.Tag] = outbound.Type
+		}
+	}
+	for _, endpoint := range options.Endpoints {
+		if endpoint.Type == C.TypeWARP {
+			entries[endpoint.Tag] = endpoint.Type
+		}
+	}
+	return entries
+}
+
+// selectWarpEntries resolves the WARP/MASQUE entries to operate on: all of them
+// when no tags are given, otherwise the requested subset. It errors if the
+// configuration declares no WARP/MASQUE outbounds, or if any requested tag is
+// unknown. Shared by the warp subcommands.
+func selectWarpEntries(options *option.Options, tags []string) (map[string]string, error) {
+	entries := collectWarpEntries(options)
+	if len(entries) == 0 {
+		return nil, E.New("configuration contains no WARP or MASQUE outbounds")
+	}
+	if len(tags) == 0 {
+		return entries, nil
+	}
+	selected := make(map[string]string, len(tags))
+	var notFound []string
+	for _, tag := range tags {
+		typ, ok := entries[tag]
+		if !ok {
+			notFound = append(notFound, tag)
+			continue
+		}
+		selected[tag] = typ
+	}
+	if len(notFound) > 0 {
+		return nil, warpTagsNotFoundError(common.Uniq(notFound))
+	}
+	return selected, nil
+}
+
+// loadWarpProfiles returns the profile stored in the cache for each entry. It
+// errors when any entry has no profile generated yet. Shared by the warp subcommands.
+func loadWarpProfiles(cacheFile adapter.CacheFile, entries map[string]string) (map[string]*adapter.SavedBinary, error) {
+	stored := make(map[string]*adapter.SavedBinary, len(entries))
+	var notStored []string
+	for tag, typ := range entries {
+		var saved *adapter.SavedBinary
+		switch typ {
+		case C.TypeMASQUE:
+			saved = cacheFile.LoadMASQUEConfig(tag)
+		case C.TypeWARP:
+			saved = cacheFile.LoadWARPConfig(tag)
+		}
+		if saved == nil {
+			notStored = append(notStored, tag)
+			continue
+		}
+		stored[tag] = saved
+	}
+	if len(notStored) > 0 {
+		return nil, warpTagsNotGeneratedError(notStored)
+	}
+	return stored, nil
+}
+
+// warpTagsNotFoundError lists requested tags that are not WARP/MASQUE outbounds.
+type warpTagsNotFoundError []string
+
+func (e warpTagsNotFoundError) Error() string {
+	return "no WARP/MASQUE endpoint/outbound with tags: " + strings.Join(e, ", ")
+}
+
+// warpTagsNotGeneratedError lists WARP/MASQUE tags that have no stored profile yet.
+type warpTagsNotGeneratedError []string
+
+func (e warpTagsNotGeneratedError) Error() string {
+	return "no stored profile for tags: " + strings.Join(e, ", ")
+}

--- a/cmd/sing-box/cmd_tools_warp_gen.go
+++ b/cmd/sing-box/cmd_tools_warp_gen.go
@@ -5,6 +5,7 @@ import (
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
 	E "github.com/sagernet/sing/common/exceptions"
+	N "github.com/sagernet/sing/common/network"
 
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,6 @@ func init() {
 	commandToolsWarp.AddCommand(commandToolsWarpGen)
 }
 
-// TODO: fix ignoring -o flag
 func warpGen(tags []string, force bool) error {
 	options, err := readConfigAndMerge()
 	if err != nil {
@@ -50,6 +50,16 @@ func warpGen(tags []string, force bool) error {
 		instance.Close()
 	}()
 
+	// With -o the registration request is routed through that outbound; otherwise
+	// the configured profile detour (if any) is used.
+	var dialer N.Dialer
+	if commandToolsFlagOutbound != "" {
+		dialer, err = createDialer(instance, commandToolsFlagOutbound)
+		if err != nil {
+			return err
+		}
+	}
+
 	// GenerateConfig keeps an already-stored profile unless force is set, matching
 	// the behavior of a normal start.
 	for tag, typ := range entries {
@@ -57,7 +67,7 @@ func warpGen(tags []string, force bool) error {
 		if !ok {
 			return E.New("no generator for tag: ", tag)
 		}
-		if err := generator.GenerateConfig(force); err != nil {
+		if err := generator.GenerateConfig(force, dialer); err != nil {
 			return E.Cause(err, "generate ", tag)
 		}
 	}
@@ -65,7 +75,7 @@ func warpGen(tags []string, force bool) error {
 }
 
 type warpConfigGenerator interface {
-	GenerateConfig(recreate bool) error
+	GenerateConfig(recreate bool, dialer N.Dialer) error
 }
 
 func warpGeneratorByTag(instance *box.Box, tag, typ string) (warpConfigGenerator, bool) {

--- a/cmd/sing-box/cmd_tools_warp_gen.go
+++ b/cmd/sing-box/cmd_tools_warp_gen.go
@@ -40,6 +40,21 @@ func warpGen(tags []string, force bool) error {
 	if options.Experimental == nil || options.Experimental.CacheFile == nil || !options.Experimental.CacheFile.Enabled {
 		return E.New("cache_file is not enabled in configuration")
 	}
+	// Without the matching store flag the generated profile is never persisted, so
+	// generation would be a no-op.
+	cacheFile := options.Experimental.CacheFile
+	for _, typ := range entries {
+		var stored bool
+		switch typ {
+		case C.TypeWARP:
+			stored = cacheFile.StoreWARPConfig
+		case C.TypeMASQUE:
+			stored = cacheFile.StoreMASQUEConfig
+		}
+		if !stored {
+			return E.New(`generating without storing makes no sense (`, typ, `)`)
+		}
+	}
 
 	instance, cancel, err := createPreStartedClient()
 	if err != nil {

--- a/cmd/sing-box/cmd_tools_warp_gen.go
+++ b/cmd/sing-box/cmd_tools_warp_gen.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	box "github.com/sagernet/sing-box"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/spf13/cobra"
+)
+
+var commandToolsWarpGenForce bool
+
+var commandToolsWarpGen = &cobra.Command{
+	Use:   "gen [tags...]",
+	Short: "Generate WARP/MASQUE account profiles into the cache",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := warpGen(args, commandToolsWarpGenForce)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	commandToolsWarpGen.Flags().BoolVar(&commandToolsWarpGenForce, "force", false, "regenerate even if a profile is already stored")
+	commandToolsWarp.AddCommand(commandToolsWarpGen)
+}
+
+// TODO: fix ignoring -o flag
+func warpGen(tags []string, force bool) error {
+	options, err := readConfigAndMerge()
+	if err != nil {
+		return err
+	}
+	entries, err := selectWarpEntries(&options, tags)
+	if err != nil {
+		return err
+	}
+	if options.Experimental == nil || options.Experimental.CacheFile == nil || !options.Experimental.CacheFile.Enabled {
+		return E.New("cache_file is not enabled in configuration")
+	}
+
+	instance, cancel, err := createPreStartedClient()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cancel()
+		instance.Close()
+	}()
+
+	// GenerateConfig keeps an already-stored profile unless force is set, matching
+	// the behavior of a normal start.
+	for tag, typ := range entries {
+		generator, ok := warpGeneratorByTag(instance, tag, typ)
+		if !ok {
+			return E.New("no generator for tag: ", tag)
+		}
+		if err := generator.GenerateConfig(force); err != nil {
+			return E.Cause(err, "generate ", tag)
+		}
+	}
+	return nil
+}
+
+type warpConfigGenerator interface {
+	GenerateConfig(recreate bool) error
+}
+
+func warpGeneratorByTag(instance *box.Box, tag, typ string) (warpConfigGenerator, bool) {
+	switch typ {
+	case C.TypeMASQUE:
+		if outbound, loaded := instance.Outbound().Outbound(tag); loaded {
+			generator, ok := outbound.(warpConfigGenerator)
+			return generator, ok
+		}
+	case C.TypeWARP:
+		if endpoint, loaded := instance.Endpoint().Get(tag); loaded {
+			generator, ok := endpoint.(warpConfigGenerator)
+			return generator, ok
+		}
+	}
+	return nil, false
+}

--- a/cmd/sing-box/cmd_tools_warp_get.go
+++ b/cmd/sing-box/cmd_tools_warp_get.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/experimental/cachefile"
+	"github.com/sagernet/sing-box/log"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/spf13/cobra"
+)
+
+var commandToolsWarpGet = &cobra.Command{
+	Use:   "get [tags...]",
+	Short: "Show stored WARP/MASQUE profiles",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := warpGet(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	commandToolsWarp.AddCommand(commandToolsWarpGet)
+}
+
+func warpGet(tags []string) error {
+	options, err := readConfigAndMerge()
+	if err != nil {
+		return err
+	}
+
+	entries, err := selectWarpEntries(&options, tags)
+	if err != nil {
+		return err
+	}
+
+	if options.Experimental == nil || options.Experimental.CacheFile == nil || !options.Experimental.CacheFile.Enabled {
+		return E.New("cache_file is not enabled in configuration")
+	}
+	cacheFile := cachefile.New(globalCtx, *options.Experimental.CacheFile)
+	err = cacheFile.Start(adapter.StartStateInitialize)
+	if err != nil {
+		return E.Cause(err, "open cache file")
+	}
+	defer cacheFile.Close()
+
+	stored, err := loadWarpProfiles(cacheFile, entries)
+	if err != nil {
+		return err
+	}
+
+	for tag, saved := range stored {
+		var pretty bytes.Buffer
+		if json.Indent(&pretty, saved.Content, "", "  ") != nil {
+			pretty.Reset()
+			pretty.Write(saved.Content)
+		}
+		fmt.Printf("%s (%s):\n%s\n", tag, entries[tag], pretty.Bytes())
+	}
+	return nil
+}

--- a/protocol/masque/generator.go
+++ b/protocol/masque/generator.go
@@ -12,21 +12,23 @@ import (
 	"github.com/sagernet/sing-box/transport/masque"
 	E "github.com/sagernet/sing/common/exceptions"
 	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // GenerateConfig provisions the MASQUE account into the cache: it keeps the cached
 // profile when present, or registers a new one. With recreate it always registers
-// a fresh one. It does not start the tunnel.
-func (w *Outbound) GenerateConfig(recreate bool) error {
-	_, err := w.provisionConfig(recreate)
+// a fresh one. When dialer is non-nil, the registration request goes through it
+// instead of the configured profile detour. It does not start the tunnel.
+func (w *Outbound) GenerateConfig(recreate bool, dialer N.Dialer) error {
+	_, err := w.provisionConfig(recreate, dialer)
 	return err
 }
 
 // provisionConfig returns the MASQUE config, loading it from the cache or creating
 // (and caching) a new one. With recreate it ignores the cache and creates a fresh config.
-func (w *Outbound) provisionConfig(recreate bool) (*Config, error) {
+func (w *Outbound) provisionConfig(recreate bool, dialer N.Dialer) (*Config, error) {
 	cacheFile := service.FromContext[adapter.CacheFile](w.ctx)
 	var appConfig *Config
 	var err error
@@ -39,7 +41,7 @@ func (w *Outbound) provisionConfig(recreate bool) (*Config, error) {
 		}
 	}
 	if appConfig == nil {
-		appConfig, err = w.createConfig()
+		appConfig, err = w.createConfig(dialer)
 		if err != nil {
 			return nil, err
 		}
@@ -58,9 +60,13 @@ func (w *Outbound) provisionConfig(recreate bool) (*Config, error) {
 	return appConfig, nil
 }
 
-func (w *Outbound) createConfig() (*Config, error) {
+func (w *Outbound) createConfig(dialer N.Dialer) (*Config, error) {
 	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
-	if w.options.Profile.Detour != "" {
+	if dialer != nil {
+		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+		}))
+	} else if w.options.Profile.Detour != "" {
 		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
 		if !ok {
 			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)

--- a/protocol/masque/generator.go
+++ b/protocol/masque/generator.go
@@ -1,0 +1,111 @@
+package masque
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/cloudflare"
+	"github.com/sagernet/sing-box/transport/masque"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/service"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// GenerateConfig provisions the MASQUE account into the cache: it keeps the cached
+// profile when present, or registers a new one. With recreate it always registers
+// a fresh one. It does not start the tunnel.
+func (w *Outbound) GenerateConfig(recreate bool) error {
+	_, err := w.provisionConfig(recreate)
+	return err
+}
+
+// provisionConfig returns the MASQUE config, loading it from the cache or creating
+// (and caching) a new one. With recreate it ignores the cache and creates a fresh config.
+func (w *Outbound) provisionConfig(recreate bool) (*Config, error) {
+	cacheFile := service.FromContext[adapter.CacheFile](w.ctx)
+	var appConfig *Config
+	var err error
+	if !recreate && cacheFile != nil && cacheFile.StoreMASQUEConfig() {
+		savedProfile := cacheFile.LoadMASQUEConfig(w.Tag())
+		if savedProfile != nil {
+			if err = json.Unmarshal(savedProfile.Content, &appConfig); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if appConfig == nil {
+		appConfig, err = w.createConfig()
+		if err != nil {
+			return nil, err
+		}
+		if cacheFile != nil && cacheFile.StoreMASQUEConfig() {
+			content, err := json.Marshal(appConfig)
+			if err != nil {
+				return nil, err
+			}
+			cacheFile.SaveMASQUEConfig(w.Tag(), &adapter.SavedBinary{
+				LastUpdated: time.Now(),
+				Content:     content,
+				LastEtag:    "",
+			})
+		}
+	}
+	return appConfig, nil
+}
+
+func (w *Outbound) createConfig() (*Config, error) {
+	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
+	if w.options.Profile.Detour != "" {
+		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
+		if !ok {
+			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)
+		}
+		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return detour.DialContext(ctx, network, M.ParseSocksaddr(addr))
+		}))
+	}
+	api := cloudflare.NewCloudflareApi(opts...)
+	var profile *cloudflare.CloudflareProfile
+	var err error
+	if w.options.Profile.AuthToken != "" && w.options.Profile.ID != "" {
+		profile, err = api.GetProfile(w.ctx, w.options.Profile.AuthToken, w.options.Profile.ID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		wgPrivateKey, err := wgtypes.GeneratePrivateKey()
+		if err != nil {
+			return nil, err
+		}
+		profile, err = api.CreateProfile(w.ctx, wgPrivateKey.PublicKey().String())
+		if err != nil {
+			return nil, err
+		}
+	}
+	privateKey, publicKey, err := masque.GenerateEcKeyPair()
+	if err != nil {
+		return nil, E.New("failed to generate key pair: ", err)
+	}
+	updatedProfile, err := api.EnrollKey(w.ctx, profile.Token, profile.ID, cloudflare.KeyTypeMasque, cloudflare.TunTypeMasque, base64.StdEncoding.EncodeToString(publicKey))
+	if err != nil {
+		return nil, err
+	}
+	return &Config{
+		PrivateKey:     base64.StdEncoding.EncodeToString(privateKey),
+		EndpointV4:     updatedProfile.Config.Peers[0].Endpoint.V4[:len(updatedProfile.Config.Peers[0].Endpoint.V4)-2],
+		EndpointV6:     updatedProfile.Config.Peers[0].Endpoint.V6[1 : len(updatedProfile.Config.Peers[0].Endpoint.V6)-3],
+		EndpointH2V4:   cloudflare.DefaultEndpointH2V4,
+		EndpointH2V6:   cloudflare.DefaultEndpointH2V6,
+		EndpointPubKey: updatedProfile.Config.Peers[0].PublicKey,
+		License:        updatedProfile.Account.License,
+		ID:             updatedProfile.ID,
+		AccessToken:    profile.Token,
+		IPv4:           updatedProfile.Config.Interface.Addresses.V4,
+		IPv6:           updatedProfile.Config.Interface.Addresses.V6,
+	}, nil
+}

--- a/protocol/masque/outbound.go
+++ b/protocol/masque/outbound.go
@@ -2,8 +2,6 @@ package masque
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"net"
 	"net/netip"
 	"time"
@@ -24,7 +22,6 @@ import (
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func RegisterOutbound(registry *outbound.Registry) {
@@ -54,36 +51,10 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 	}
 	outbound.startHandler = func() {
 		defer close(outbound.await)
-		cacheFile := service.FromContext[adapter.CacheFile](ctx)
-		var appConfig *Config
-		var err error
-		if !options.Profile.Recreate && cacheFile != nil && cacheFile.StoreMASQUEConfig() {
-			savedProfile := cacheFile.LoadMASQUEConfig(tag)
-			if savedProfile != nil {
-				if err = json.Unmarshal(savedProfile.Content, &appConfig); err != nil {
-					logger.ErrorContext(ctx, err)
-					return
-				}
-			}
-		}
-		if appConfig == nil {
-			appConfig, err = outbound.createConfig()
-			if err != nil {
-				logger.ErrorContext(ctx, err)
-				return
-			}
-			if cacheFile != nil && cacheFile.StoreMASQUEConfig() {
-				content, err := json.Marshal(appConfig)
-				if err != nil {
-					logger.ErrorContext(ctx, err)
-					return
-				}
-				cacheFile.SaveMASQUEConfig(tag, &adapter.SavedBinary{
-					LastUpdated: time.Now(),
-					Content:     content,
-					LastEtag:    "",
-				})
-			}
+		appConfig, err := outbound.provisionConfig(options.Profile.Recreate)
+		if err != nil {
+			logger.ErrorContext(ctx, err)
+			return
 		}
 		privKey, err := appConfig.GetEcPrivateKey()
 		if err != nil {
@@ -259,56 +230,4 @@ func (w *Outbound) isTunnelInitialized(ctx context.Context) error {
 		return E.New("tunnel not initialized")
 	}
 	return nil
-}
-
-func (w *Outbound) createConfig() (*Config, error) {
-	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
-	if w.options.Profile.Detour != "" {
-		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
-		if !ok {
-			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)
-		}
-		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return detour.DialContext(ctx, network, M.ParseSocksaddr(addr))
-		}))
-	}
-	api := cloudflare.NewCloudflareApi(opts...)
-	var profile *cloudflare.CloudflareProfile
-	var err error
-	if w.options.Profile.AuthToken != "" && w.options.Profile.ID != "" {
-		profile, err = api.GetProfile(w.ctx, w.options.Profile.AuthToken, w.options.Profile.ID)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		wgPrivateKey, err := wgtypes.GeneratePrivateKey()
-		if err != nil {
-			return nil, err
-		}
-		profile, err = api.CreateProfile(w.ctx, wgPrivateKey.PublicKey().String())
-		if err != nil {
-			return nil, err
-		}
-	}
-	privateKey, publicKey, err := masque.GenerateEcKeyPair()
-	if err != nil {
-		return nil, E.New("failed to generate key pair: ", err)
-	}
-	updatedProfile, err := api.EnrollKey(w.ctx, profile.Token, profile.ID, cloudflare.KeyTypeMasque, cloudflare.TunTypeMasque, base64.StdEncoding.EncodeToString(publicKey))
-	if err != nil {
-		return nil, err
-	}
-	return &Config{
-		PrivateKey:     base64.StdEncoding.EncodeToString(privateKey),
-		EndpointV4:     updatedProfile.Config.Peers[0].Endpoint.V4[:len(updatedProfile.Config.Peers[0].Endpoint.V4)-2],
-		EndpointV6:     updatedProfile.Config.Peers[0].Endpoint.V6[1 : len(updatedProfile.Config.Peers[0].Endpoint.V6)-3],
-		EndpointH2V4:   cloudflare.DefaultEndpointH2V4,
-		EndpointH2V6:   cloudflare.DefaultEndpointH2V6,
-		EndpointPubKey: updatedProfile.Config.Peers[0].PublicKey,
-		License:        updatedProfile.Account.License,
-		ID:             updatedProfile.ID,
-		AccessToken:    profile.Token,
-		IPv4:           updatedProfile.Config.Interface.Addresses.V4,
-		IPv6:           updatedProfile.Config.Interface.Addresses.V6,
-	}, nil
 }

--- a/protocol/masque/outbound.go
+++ b/protocol/masque/outbound.go
@@ -51,7 +51,7 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 	}
 	outbound.startHandler = func() {
 		defer close(outbound.await)
-		appConfig, err := outbound.provisionConfig(options.Profile.Recreate)
+		appConfig, err := outbound.provisionConfig(options.Profile.Recreate, nil)
 		if err != nil {
 			logger.ErrorContext(ctx, err)
 			return

--- a/protocol/warp/endpoint.go
+++ b/protocol/warp/endpoint.go
@@ -50,7 +50,7 @@ func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextL
 	}
 	endpoint.startHandler = func() {
 		defer close(endpoint.await)
-		config, err := endpoint.provisionConfig(options.Profile.Recreate)
+		config, err := endpoint.provisionConfig(options.Profile.Recreate, nil)
 		if err != nil {
 			logger.ErrorContext(ctx, err)
 			return

--- a/protocol/warp/endpoint.go
+++ b/protocol/warp/endpoint.go
@@ -2,16 +2,13 @@ package warp
 
 import (
 	"context"
-	"encoding/json"
 	"math/rand"
 	"net"
 	"net/netip"
 	"strings"
-	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
-	"github.com/sagernet/sing-box/common/cloudflare"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
@@ -21,8 +18,6 @@ import (
 	"github.com/sagernet/sing/common/json/badoption"
 	M "github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
-	"github.com/sagernet/sing/service"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func RegisterEndpoint(registry *endpoint.Registry) {
@@ -55,36 +50,10 @@ func NewEndpoint(ctx context.Context, router adapter.Router, logger log.ContextL
 	}
 	endpoint.startHandler = func() {
 		defer close(endpoint.await)
-		cacheFile := service.FromContext[adapter.CacheFile](ctx)
-		var config *Config
-		var err error
-		if !options.Profile.Recreate && cacheFile != nil && cacheFile.StoreWARPConfig() {
-			savedProfile := cacheFile.LoadWARPConfig(tag)
-			if savedProfile != nil {
-				if err = json.Unmarshal(savedProfile.Content, &config); err != nil {
-					logger.ErrorContext(ctx, err)
-					return
-				}
-			}
-		}
-		if config == nil {
-			config, err = endpoint.createConfig()
-			if err != nil {
-				logger.ErrorContext(ctx, err)
-				return
-			}
-			if cacheFile != nil && cacheFile.StoreWARPConfig() {
-				content, err := json.Marshal(config)
-				if err != nil {
-					logger.ErrorContext(ctx, err)
-					return
-				}
-				cacheFile.SaveWARPConfig(tag, &adapter.SavedBinary{
-					LastUpdated: time.Now(),
-					Content:     content,
-					LastEtag:    "",
-				})
-			}
+		config, err := endpoint.provisionConfig(options.Profile.Recreate)
+		if err != nil {
+			logger.ErrorContext(ctx, err)
+			return
 		}
 		peer := config.Peers[0]
 		hostParts := strings.Split(peer.Endpoint.Host, ":")
@@ -179,48 +148,4 @@ func (w *Endpoint) isEndpointInitialized(ctx context.Context) error {
 		return E.New("endpoint not initialized")
 	}
 	return nil
-}
-
-func (w *Endpoint) createConfig() (*Config, error) {
-	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
-	if w.options.Profile.Detour != "" {
-		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
-		if !ok {
-			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)
-		}
-		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return detour.DialContext(ctx, network, M.ParseSocksaddr(addr))
-		}))
-	}
-	var privateKey wgtypes.Key
-	var err error
-	if w.options.Profile.PrivateKey != "" {
-		privateKey, err = wgtypes.ParseKey(w.options.Profile.PrivateKey)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		privateKey, err = wgtypes.GeneratePrivateKey()
-		if err != nil {
-			return nil, err
-		}
-	}
-	api := cloudflare.NewCloudflareApi(opts...)
-	var profile *cloudflare.CloudflareProfile
-	if w.options.Profile.AuthToken != "" && w.options.Profile.ID != "" {
-		profile, err = api.GetProfile(w.ctx, w.options.Profile.AuthToken, w.options.Profile.ID)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		profile, err = api.CreateProfile(w.ctx, privateKey.PublicKey().String())
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &Config{
-		PrivateKey: privateKey.String(),
-		Interface:  profile.Config.Interface,
-		Peers:      profile.Config.Peers,
-	}, nil
 }

--- a/protocol/warp/generator.go
+++ b/protocol/warp/generator.go
@@ -1,0 +1,101 @@
+package warp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/cloudflare"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/service"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// GenerateConfig provisions the WARP account into the cache: it keeps the cached
+// profile when present, or registers a new one. With recreate it always registers
+// a fresh one. It does not start the endpoint.
+func (w *Endpoint) GenerateConfig(recreate bool) error {
+	_, err := w.provisionConfig(recreate)
+	return err
+}
+
+// provisionConfig returns the WARP config, loading it from the cache or creating
+// (and caching) a new one. With recreate it ignores the cache and creates a fresh config.
+func (w *Endpoint) provisionConfig(recreate bool) (*Config, error) {
+	cacheFile := service.FromContext[adapter.CacheFile](w.ctx)
+	var config *Config
+	var err error
+	if !recreate && cacheFile != nil && cacheFile.StoreWARPConfig() {
+		savedProfile := cacheFile.LoadWARPConfig(w.Tag())
+		if savedProfile != nil {
+			if err = json.Unmarshal(savedProfile.Content, &config); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if config == nil {
+		config, err = w.createConfig()
+		if err != nil {
+			return nil, err
+		}
+		if cacheFile != nil && cacheFile.StoreWARPConfig() {
+			content, err := json.Marshal(config)
+			if err != nil {
+				return nil, err
+			}
+			cacheFile.SaveWARPConfig(w.Tag(), &adapter.SavedBinary{
+				LastUpdated: time.Now(),
+				Content:     content,
+				LastEtag:    "",
+			})
+		}
+	}
+	return config, nil
+}
+
+func (w *Endpoint) createConfig() (*Config, error) {
+	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
+	if w.options.Profile.Detour != "" {
+		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
+		if !ok {
+			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)
+		}
+		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return detour.DialContext(ctx, network, M.ParseSocksaddr(addr))
+		}))
+	}
+	var privateKey wgtypes.Key
+	var err error
+	if w.options.Profile.PrivateKey != "" {
+		privateKey, err = wgtypes.ParseKey(w.options.Profile.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		privateKey, err = wgtypes.GeneratePrivateKey()
+		if err != nil {
+			return nil, err
+		}
+	}
+	api := cloudflare.NewCloudflareApi(opts...)
+	var profile *cloudflare.CloudflareProfile
+	if w.options.Profile.AuthToken != "" && w.options.Profile.ID != "" {
+		profile, err = api.GetProfile(w.ctx, w.options.Profile.AuthToken, w.options.Profile.ID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		profile, err = api.CreateProfile(w.ctx, privateKey.PublicKey().String())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Config{
+		PrivateKey: privateKey.String(),
+		Interface:  profile.Config.Interface,
+		Peers:      profile.Config.Peers,
+	}, nil
+}

--- a/protocol/warp/generator.go
+++ b/protocol/warp/generator.go
@@ -10,21 +10,23 @@ import (
 	"github.com/sagernet/sing-box/common/cloudflare"
 	E "github.com/sagernet/sing/common/exceptions"
 	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
 	"github.com/sagernet/sing/service"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // GenerateConfig provisions the WARP account into the cache: it keeps the cached
 // profile when present, or registers a new one. With recreate it always registers
-// a fresh one. It does not start the endpoint.
-func (w *Endpoint) GenerateConfig(recreate bool) error {
-	_, err := w.provisionConfig(recreate)
+// a fresh one. When dialer is non-nil, the registration request goes through it
+// instead of the configured profile detour. It does not start the endpoint.
+func (w *Endpoint) GenerateConfig(recreate bool, dialer N.Dialer) error {
+	_, err := w.provisionConfig(recreate, dialer)
 	return err
 }
 
 // provisionConfig returns the WARP config, loading it from the cache or creating
 // (and caching) a new one. With recreate it ignores the cache and creates a fresh config.
-func (w *Endpoint) provisionConfig(recreate bool) (*Config, error) {
+func (w *Endpoint) provisionConfig(recreate bool, dialer N.Dialer) (*Config, error) {
 	cacheFile := service.FromContext[adapter.CacheFile](w.ctx)
 	var config *Config
 	var err error
@@ -37,7 +39,7 @@ func (w *Endpoint) provisionConfig(recreate bool) (*Config, error) {
 		}
 	}
 	if config == nil {
-		config, err = w.createConfig()
+		config, err = w.createConfig(dialer)
 		if err != nil {
 			return nil, err
 		}
@@ -56,9 +58,13 @@ func (w *Endpoint) provisionConfig(recreate bool) (*Config, error) {
 	return config, nil
 }
 
-func (w *Endpoint) createConfig() (*Config, error) {
+func (w *Endpoint) createConfig(dialer N.Dialer) (*Config, error) {
 	opts := make([]cloudflare.CloudflareApiOption, 0, 1)
-	if w.options.Profile.Detour != "" {
+	if dialer != nil {
+		opts = append(opts, cloudflare.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+		}))
+	} else if w.options.Profile.Detour != "" {
 		detour, ok := service.FromContext[adapter.OutboundManager](w.ctx).Outbound(w.options.Profile.Detour)
 		if !ok {
 			return nil, E.New("outbound detour not found: ", w.options.Profile.Detour)


### PR DESCRIPTION
Вынесена логика регистрации аккаунтов и работы с кэшем для WARP и MASQUE в отдельные генераторы.

Изначальное поведение регистрации на старте не затронуто. Команды, как и любые в `tools`, поддерживают флаги `-c` и `-o`. Это всё ещё работа с кешем, и ядро не превращается в "генератор".

Дополнительно, в коммите 1d31150c42b5dbda487aba5d2877556e1640441e исправил ошибку зависания ядра при старте `PreStartedClient`. Без него клиент для аутбаундов, не готовых на момент `PreStarted`, зависал на закрытии инстанса. Повторил логику закрытия из `cmd\sing-box\cmd_run.go`. `tools` всё ещё не будет работать для таких аутбаундов (присутствовало и ранее), но это другая проблема и связана с тем, что аутбаунд не готов на момент `PreStarted`.

### Зачем
* Иногда возникает необходимость сгенерировать конфиг без запуска ядра.
* Сейчас ядро не падает с ошибкой при неуспешной генерации. В случае явной генерации ошибку можно получить сразу, в том числе из другой программы.
* Генерация через команды более явная, чем на этапе запуска.

Иначе говоря, дает больший контроль над конфигами, процесс генерации становится отдельной операцией, которую можно выполнять независимо от жизненного цикла.

### Основные изменения

#### Фикс зависания PreStartedClient (1d31150c42b5dbda487aba5d2877556e1640441e):
* [cmd/sing-box/cmd_tools.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp#diff-45bafce82b1a844f9a20829e58e9e7c45bc2ef28f3341b45fc8f6cc28d3c0249): `createPreStartedClient()` теперь возвращает `context.CancelFunc` от `globalCtx`, что дает корректно закрыть контекст.
* [cmd/sing-box/cmd_tools_connect.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp#diff-a885ca9b7498a2c5d154cb95bfb7517280593fd4ba7c9a9ffb59c018cd5aa924), [cmd/sing-box/cmd_tools_fetch.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp#diff-6982619aed94923b23328a2b4a095542030412fcb5aa593472897f46d53d955f), [cmd/sing-box/cmd_tools_synctime.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp#diff-4d8a311331a391da9643e9676ee3b95417993046e6efaa97e4394b7bfe8ccc90): закрывают контекст, перед закрытием инстанса.
#### Рефактор WARP/MASQUE аутбаундов (5509824d44bf622b64d136638b1ce33a693b0761, e87340777df4f7b5a86b7133f03cf17e0e320c09):
* [protocol/warp/endpoint.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-8796cea41fd37e03e7756326190c07e1519d6f0bf91a05bf39486877e1750d77): логика генератора вынесена в [protocol/warp/generator.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-62424251ffbeccc3e24598410ff572f7d8d947a14bbb9fac225d25859579f9de).
* [protocol/masque/outbound.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-a1d33f17b4e9ce319678199eee7b00fb83836496d897ccbbeb7186be8df01ef5): логика генератора вынесена в [protocol/masque/generator.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-6e4d65f65804c57775a987c260f48a31163e2188385fcddf8c5a7c3c90bebd80).
* Изменена сигнатура `createConfig() (*Config, error)` на `createConfig(dialer N.Dialer) (*Config, error)` для поддержки флага `-o`.
#### Реализация `warp get/gen` (f53b9f8e861ba7e5c1477716c919f263068dd6fa, 81b344026bbd8264069e4c473838cff9df8fda3e, fecee91c35fff88b6fc46973bed1c47c42e19828):
* [cmd/sing-box/cmd_tools_warp.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-e6919a6d7dac694896ddc8d2661f4ecc1ea41a7de31a65d05b2178edd8eb4d81): команда `warp` и функции хелперы.
* [cmd/sing-box/cmd_tools_warp_get.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-6ee5e2df3e123b44ef59a14e2ac755541f1a738232166dae6106d2f86d2ee479): команда `warp get`.
* [cmd/sing-box/cmd_tools_warp_gen.go](https://github.com/shtorm-7/sing-box-extended/compare/extended...v14d4n:throne-sing-box-awg:feat/tools-warp?diff=split&w#diff-51a7ed968a61497de281db521e282858f33a1e2ca4a347c1581478ca6edd554c): команда `warp gen`.

### Принцип работы
`get`: 
1. Тулза читает конфиг на наличие кеша и WARP/MASQUE аутбаундов -> если таких нет, то выдает ошибку.
2. Проверяет теги из команды -> если хотя бы один из искомых тегов не находится в конфиге, то выдает ошибку.
3. Идет в кеш -> если хотя бы одного нет в кеше, то выдает ошибку.
4. Выводит конфиги через `Printf`.

В случае если теги в команде явно не указаны, то берутся все из конфига. Ошибки содержат недостающие теги. 

`gen`:
1. Первые 2 этапа из `get`.
2. Проверяет `cacheFile.StoreWARPConfig` и `cacheFile.StoreMASQUEConfig` для указаных тегов. Если их нет, то генерация не имеет смысла - выдает ошибку.
3. Найденные теги отдаются оригинальной имплементации генерации. Флаг `--force` аналогичен `options.Profile.Recreate`.

### Послесловие
Буду рад видеть этот функционал в ядре, чтобы не тянуть отдельный форк.