### PR TITLE
transport/v2rayxhttp: close UDP connection when HTTP/3 dial fails

### DIFF
--- a/transport/v2rayxhttp/client.go
+++ b/transport/v2rayxhttp/client.go
@@ -348,6 +348,7 @@ func createHTTPClient(ctx context.Context, dest M.Socksaddr, dialer N.Dialer, op
 				}
 				conn, dErr := qtls.DialEarly(ctx, bufio.NewUnbindPacketConn(udpConn), udpConn.RemoteAddr(), tlsConfig, cfg)
 				if dErr != nil {
+					_ = udpConn.Close()
 					return nil, dErr
 				}
 				if congestionControlFactory != nil {


### PR DESCRIPTION
Close `udpConn` when `qtls.DialEarly()` fails. Without this, repeated XHTTP HTTP/3 connection attempts leak one UDP socket and file descriptor per failure.

Verified with 100 failed checks. The file descriptor count remained stable and no stale UDP sockets were left open.

Fixes #115