### PR TITLE
feat(parser/provider): Adding Endpoint (Wireguard) support

### DIFF
--- a/adapter/provider/adapter.go
+++ b/adapter/provider/adapter.go
@@ -23,6 +23,7 @@ import (
 type Adapter struct {
 	ctx            context.Context
 	outbound       adapter.OutboundManager
+	endpoint       adapter.EndpointManager
 	router         adapter.Router
 	logFactory     log.Factory
 	logger         log.ContextLogger
@@ -43,7 +44,7 @@ type Adapter struct {
 	interval     time.Duration
 }
 
-func NewAdapter(ctx context.Context, router adapter.Router, outbound adapter.OutboundManager, logFactory log.Factory, logger log.ContextLogger, providerTag string, providerType string, options option.ProviderHealthCheckOptions) Adapter {
+func NewAdapter(ctx context.Context, router adapter.Router, outbound adapter.OutboundManager, endpoint adapter.EndpointManager, logFactory log.Factory, logger log.ContextLogger, providerTag string, providerType string, options option.ProviderHealthCheckOptions) Adapter {
 	timeout := time.Duration(options.Timeout)
 	if timeout == 0 {
 		timeout = 3 * time.Second
@@ -58,6 +59,7 @@ func NewAdapter(ctx context.Context, router adapter.Router, outbound adapter.Out
 	return Adapter{
 		ctx:          ctx,
 		outbound:     outbound,
+		endpoint:     endpoint,
 		router:       router,
 		logFactory:   logFactory,
 		logger:       logger,
@@ -190,10 +192,18 @@ func (a *Adapter) Close() error {
 	a.outbounds = nil
 	var err error
 	for _, ob := range outbounds {
-		if err2 := a.outbound.Remove(ob.Tag()); err2 != nil {
-			err = E.Append(err, err2, func(err error) error {
-				return E.Cause(err, "close outbound [", ob.Tag(), "]")
-			})
+		if _, isEndpoint := a.endpoint.Get(ob.Tag()); isEndpoint {
+			if err2 := a.endpoint.Remove(ob.Tag()); err2 != nil {
+				err = E.Append(err, err2, func(err error) error {
+					return E.Cause(err, "close endpoint [", ob.Tag(), "]")
+				})
+			}
+		} else {
+			if err2 := a.outbound.Remove(ob.Tag()); err2 != nil {
+				err = E.Append(err, err2, func(err error) error {
+					return E.Cause(err, "close outbound [", ob.Tag(), "]")
+				})
+			}
 		}
 	}
 	return err
@@ -253,6 +263,77 @@ func (a *Adapter) healthcheck(ctx context.Context) (map[string]uint16, error) {
 	b.Wait()
 	return result, nil
 }
+
+func (a *Adapter) UpdateEndpoints(oldOpts []option.Endpoint, newOpts []option.Endpoint) {
+	a.removeUselessEndpoints(newOpts)
+	var (
+		oldOptByTag = make(map[string]option.Endpoint)
+		endpoints   []adapter.Outbound
+	)
+	for _, opt := range oldOpts {
+		oldOptByTag[opt.Tag] = opt
+	}
+	for i, opt := range newOpts {
+		var tag string
+		if opt.Tag != "" {
+			tag = F.ToString(a.providerTag, "/", opt.Tag)
+		} else {
+			tag = F.ToString(a.providerTag, "/", i)
+		}
+		ep, exist := a.endpoint.Get(tag)
+		if !exist || !reflect.DeepEqual(opt, oldOptByTag[opt.Tag]) {
+			err := a.endpoint.Create(
+				adapter.WithContext(a.ctx, &adapter.InboundContext{
+					Outbound: tag,
+				}),
+				a.router,
+				a.logFactory.NewLogger(F.ToString("endpoint/", opt.Type, "[", tag, "]")),
+				tag,
+				opt.Type,
+				opt.Options,
+			)
+			if err != nil {
+				a.logger.Warn(err, " in ", tag, ", skip create this endpoint")
+				continue
+			}
+			ep, _ = a.endpoint.Get(tag)
+		}
+		endpoints = append(endpoints, ep)
+	}
+	a.outbounds = append(a.outbounds, endpoints...)
+	if a.outboundsByTag == nil {
+		a.outboundsByTag = make(map[string]adapter.Outbound)
+	}
+	for _, ep := range endpoints {
+		a.outboundsByTag[ep.Tag()] = ep
+	}
+}
+
+func (a *Adapter) removeUselessEndpoints(newOpts []option.Endpoint) {
+	exists := make(map[string]bool)
+	for i, opt := range newOpts {
+		var tag string
+		if opt.Tag != "" {
+			tag = F.ToString(a.providerTag, "/", opt.Tag)
+		} else {
+			tag = F.ToString(a.providerTag, "/", i)
+		}
+		exists[tag] = true
+	}
+	var remaining []adapter.Outbound
+	for _, ob := range a.outbounds {
+		if _, isEndpoint := a.endpoint.Get(ob.Tag()); isEndpoint && !exists[ob.Tag()] {
+			if err := a.endpoint.Remove(ob.Tag()); err != nil {
+				a.logger.Error(err, "close endpoint [", ob.Tag(), "]")
+			}
+			delete(a.outboundsByTag, ob.Tag())
+			continue
+		}
+		remaining = append(remaining, ob)
+	}
+	a.outbounds = remaining
+}
+
 
 func (a *Adapter) removeUseless(newOpts []option.Outbound) {
 	if len(a.outbounds) == 0 {

--- a/option/provider.go
+++ b/option/provider.go
@@ -67,6 +67,7 @@ type ProviderRemoteOptions struct {
 
 type ProviderInlineOptions struct {
 	Outbounds    []Outbound                 `json:"outbounds,omitempty"`
+	Endpoints    []Endpoint                 `json:"endpoints,omitempty"`
 	RemoveEmojis bool                       `json:"remove_emojis,omitempty"`
 	HealthCheck  ProviderHealthCheckOptions `json:"health_check,omitempty"`
 }

--- a/parser/clash/parser.go
+++ b/parser/clash/parser.go
@@ -68,6 +68,9 @@ func (c *ClashProxy) UnmarshalYAML(value *yaml.Node) error {
 	case "anytls":
 		c.SingType = C.TypeAnyTLS
 		options = &AnyTLSOption{}
+	case "wireguard":
+		c.SingType = C.TypeWireGuard
+		options = &ClashWireGuardOption{}
 	default:
 		return nil
 	}
@@ -90,17 +93,37 @@ func (c *ClashProxy) Build() option.Outbound {
 	return outbound
 }
 
-func ParseClashSubscription(_ context.Context, content string) ([]option.Outbound, error) {
+func (c *ClashProxy) BuildEndpoint() option.Endpoint {
+	endpoint := option.Endpoint{
+		Tag:  c.Name,
+		Type: c.SingType,
+	}
+	if c.Options != nil {
+		endpoint.Options = c.Options.Build()
+	}
+	return endpoint
+}
+
+func ParseClashSubscription(_ context.Context, content string) ([]option.Outbound, []option.Endpoint, error) {
 	config := &ClashConfig{}
 	err := yaml.Unmarshal([]byte(content), &config)
 	if err != nil {
-		return nil, E.Cause(err, "parse clash config")
+		return nil, nil, E.Cause(err, "parse clash config")
 	}
 	outbounds := common.FilterIsInstance(config.Proxies, func(proxy ClashProxy) (option.Outbound, bool) {
-		if proxy.SingType == "" {
+		if proxy.SingType == "" || proxy.SingType == C.TypeWireGuard {
 			return option.Outbound{}, false
 		}
 		return proxy.Build(), true
 	})
-	return outbounds, nil
+	endpoints := common.FilterIsInstance(config.Proxies, func(proxy ClashProxy) (option.Endpoint, bool) {
+		if proxy.SingType != C.TypeWireGuard {
+			return option.Endpoint{}, false
+		}
+		if wgOpt, ok := proxy.Options.(*ClashWireGuardOption); ok && wgOpt.AmneziaWGOption != nil {
+			return option.Endpoint{}, false
+		}
+		return proxy.BuildEndpoint(), true
+	})
+	return outbounds, endpoints, nil
 }

--- a/parser/clash/wg.go
+++ b/parser/clash/wg.go
@@ -1,0 +1,110 @@
+package clash
+
+import (
+	"net/netip"
+	"encoding/base64"
+	"strings"
+
+	"github.com/sagernet/sing/common/json/badoption"
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ClashWireGuardReserved []uint8
+
+func (r *ClashWireGuardReserved) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		decoded, err := base64.StdEncoding.DecodeString(value.Value)
+		if err != nil {
+			return E.Cause(err, "decode reserved")
+		}
+		*r = decoded
+		return nil
+	}
+	var reserved []uint8
+	if err := value.Decode(&reserved); err != nil {
+		return err
+	}
+	*r = reserved
+	return nil
+}
+
+type ClashWireGuardPeerOption struct {
+	Server       string                 `yaml:"server"`
+	Port         int                    `yaml:"port"`
+	PublicKey    string                 `yaml:"public-key,omitempty"`
+	PreSharedKey string                 `yaml:"pre-shared-key,omitempty"`
+	Reserved     ClashWireGuardReserved `yaml:"reserved,omitempty"`
+	AllowedIPs   []string               `yaml:"allowed-ips,omitempty"`
+}
+
+type ClashWireGuardOption struct {
+	DialerOptions            `yaml:",inline"`
+	ClashWireGuardPeerOption `yaml:",inline"`
+	Ip                       string                     `yaml:"ip,omitempty"`
+	Ipv6                     string                     `yaml:"ipv6,omitempty"`
+	PrivateKey               string                     `yaml:"private-key"`
+	MTU                      int                        `yaml:"mtu,omitempty"`
+	Workers                  int                        `yaml:"workers,omitempty"`
+	PersistentKeepalive      int                        `yaml:"persistent-keepalive,omitempty"`
+	Peers                    []ClashWireGuardPeerOption `yaml:"peers,omitempty"`
+	AmneziaWGOption          map[string]any             `yaml:"amnezia-wg-option,omitempty"`
+}
+
+func (w *ClashWireGuardOption) Build() any {
+	var address badoption.Listable[netip.Prefix]
+	if w.Ip != "" {
+		ip := w.Ip
+		if !strings.Contains(ip, "/") {
+			ip += "/32"
+		}
+		if prefix, err := netip.ParsePrefix(ip); err == nil {
+			address = append(address, prefix)
+		}
+	}
+	if w.Ipv6 != "" {
+		ipv6 := w.Ipv6
+		if !strings.Contains(ipv6, "/") {
+			ipv6 += "/128"
+		}
+		if prefix, err := netip.ParsePrefix(ipv6); err == nil {
+			address = append(address, prefix)
+		}
+	}
+	var peers []option.WireGuardPeer
+	if len(w.Peers) > 0 {
+		for _, peer := range w.Peers {
+			peers = append(peers, clashWireGuardPeer(peer, w.PersistentKeepalive))
+		}
+	} else {
+		peers = append(peers, clashWireGuardPeer(w.ClashWireGuardPeerOption, w.PersistentKeepalive))
+	}
+	return &option.WireGuardEndpointOptions{
+		Address:       address,
+		PrivateKey:    w.PrivateKey,
+		MTU:           uint32(w.MTU),
+		Workers:       w.Workers,
+		Peers:         peers,
+		DialerOptions: w.DialerOptions.Build(),
+	}
+}
+
+func clashWireGuardPeer(peer ClashWireGuardPeerOption, persistentKeepalive int) option.WireGuardPeer {
+	var allowedIPs badoption.Listable[netip.Prefix]
+	for _, ip := range peer.AllowedIPs {
+		if prefix, err := netip.ParsePrefix(ip); err == nil {
+			allowedIPs = append(allowedIPs, prefix)
+		}
+	}
+	return option.WireGuardPeer{
+		Address:                     peer.Server,
+		Port:                        uint16(peer.Port),
+		PublicKey:                   peer.PublicKey,
+		PreSharedKey:                peer.PreSharedKey,
+		AllowedIPs:                  allowedIPs,
+		PersistentKeepaliveInterval: uint16(persistentKeepalive),
+	}
+}
+

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,21 +11,21 @@ import (
 	E "github.com/sagernet/sing/common/exceptions"
 )
 
-var subscriptionParsers = []func(ctx context.Context, content string) ([]option.Outbound, error){
+var subscriptionParsers = []func(ctx context.Context, content string) ([]option.Outbound, []option.Endpoint, error){
 	singbox.ParseBoxSubscription,
 	clash.ParseClashSubscription,
 	sip008.ParseSIP008Subscription,
 	raw.ParseRawSubscription,
 }
 
-func ParseSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+func ParseSubscription(ctx context.Context, content string) ([]option.Outbound, []option.Endpoint, error) {
 	var pErr error
 	for _, parser := range subscriptionParsers {
-		servers, err := parser(ctx, content)
-		if len(servers) > 0 {
-			return servers, nil
+		outbounds, endpoints, err := parser(ctx, content)
+		if len(outbounds) > 0 || len(endpoints) > 0 {
+			return outbounds, endpoints, nil
 		}
 		pErr = E.Errors(pErr, err)
 	}
-	return nil, E.Cause(pErr, "no servers found")
+	return nil, nil, E.Cause(pErr, "no servers found")
 }

--- a/parser/raw/parser.go
+++ b/parser/raw/parser.go
@@ -10,14 +10,15 @@ import (
 	E "github.com/sagernet/sing/common/exceptions"
 )
 
-func ParseRawSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+func ParseRawSubscription(ctx context.Context, content string) ([]option.Outbound, []option.Endpoint, error) {
 	if base64Content, err := DecodeBase64URLSafe(content); err == nil {
 		servers, _ := parseRawSubscription(base64Content)
 		if len(servers) > 0 {
-			return servers, err
+			return servers, nil, err
 		}
 	}
-	return parseRawSubscription(content)
+	outbounds, err := parseRawSubscription(content)
+	return outbounds, nil, err
 }
 
 func parseRawSubscription(content string) ([]option.Outbound, error) {

--- a/parser/singbox/parser.go
+++ b/parser/singbox/parser.go
@@ -12,6 +12,7 @@ import (
 
 type _SingBoxDocument struct {
 	Outbounds []option.Outbound `json:"outbounds"`
+	Endpoints []option.Endpoint `json:"endpoints"`
 }
 type SingBoxDocument _SingBoxDocument
 
@@ -21,24 +22,23 @@ func (o *SingBoxDocument) UnmarshalJSONContext(ctx context.Context, inputContent
 	if err != nil {
 		return err
 	}
-	outbounds, ok := content.Get("outbounds")
-	if !ok {
-		return E.New("missing outbounds in sing-box configuration")
-	}
-	var outs badjson.JSONArray
-	for i, outbound := range outbounds.(badjson.JSONArray) {
-		typeVal, loaded := outbound.(*badjson.JSONObject).Get("type")
-		if !loaded {
-			return E.New("missing type in outbound[", i, "]")
+	outbounds, hasOutbounds := content.Get("outbounds")
+	if hasOutbounds {
+		var outs badjson.JSONArray
+		for i, outbound := range outbounds.(badjson.JSONArray) {
+			typeVal, loaded := outbound.(*badjson.JSONObject).Get("type")
+			if !loaded {
+				return E.New("missing type in outbound[", i, "]")
+			}
+			switch typeVal.(string) {
+			case C.TypeDirect, C.TypeBlock, C.TypeDNS, C.TypeSelector, C.TypeURLTest:
+				continue
+			default:
+				outs = append(outs, outbound)
+			}
 		}
-		switch typeVal.(string) {
-		case C.TypeDirect, C.TypeBlock, C.TypeDNS, C.TypeSelector, C.TypeURLTest:
-			continue
-		default:
-			outs = append(outs, outbound)
-		}
+		content.Put("outbounds", outs)
 	}
-	content.Put("outbounds", outs)
 	inputContent, err = content.MarshalJSONContext(ctx)
 	if err != nil {
 		return err
@@ -46,13 +46,13 @@ func (o *SingBoxDocument) UnmarshalJSONContext(ctx context.Context, inputContent
 	return json.UnmarshalContext(ctx, inputContent, (*_SingBoxDocument)(o))
 }
 
-func ParseBoxSubscription(ctx context.Context, content string) ([]option.Outbound, error) {
+func ParseBoxSubscription(ctx context.Context, content string) ([]option.Outbound, []option.Endpoint, error) {
 	options, err := json.UnmarshalExtendedContext[SingBoxDocument](ctx, []byte(content))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if len(options.Outbounds) == 0 {
-		return nil, E.New("no servers found")
+	if len(options.Outbounds) == 0 && len(options.Endpoints) == 0 {
+		return nil, nil, E.New("no servers found")
 	}
-	return options.Outbounds, nil
+	return options.Outbounds, options.Endpoints, nil
 }

--- a/parser/sip008/parser.go
+++ b/parser/sip008/parser.go
@@ -25,11 +25,11 @@ type ShadowsocksServerDocument struct {
 	PluginOpts string `json:"plugin_opts"`
 }
 
-func ParseSIP008Subscription(_ context.Context, content string) ([]option.Outbound, error) {
+func ParseSIP008Subscription(_ context.Context, content string) ([]option.Outbound, []option.Endpoint, error) {
 	var document ShadowsocksDocument
 	err := json.Unmarshal([]byte(content), &document)
 	if err != nil {
-		return nil, E.Cause(err, "parse SIP008 document")
+		return nil, nil, E.Cause(err, "parse SIP008 document")
 	}
 
 	var servers []option.Outbound
@@ -49,5 +49,5 @@ func ParseSIP008Subscription(_ context.Context, content string) ([]option.Outbou
 			},
 		})
 	}
-	return servers, nil
+	return servers, nil, nil
 }

--- a/provider/local/provider.go
+++ b/provider/local/provider.go
@@ -37,22 +37,27 @@ type ProviderLocal struct {
 	provider    adapter.ProviderManager
 	path        string
 	lastOutOpts []option.Outbound
+	lastEPOpts  []option.Endpoint
 	lastUpdated time.Time
 	watcher     *fswatch.Watcher
 }
 
 func NewProviderInline(ctx context.Context, router adapter.Router, logFactory log.Factory, tag string, options option.ProviderInlineOptions) (adapter.Provider, error) {
 	var (
-		outbound = service.FromContext[adapter.OutboundManager](ctx)
-		logger   = logFactory.NewLogger(F.ToString("provider/inline", "[", tag, "]"))
+		outbound    = service.FromContext[adapter.OutboundManager](ctx)
+		endpointMgr = service.FromContext[adapter.EndpointManager](ctx)
+		logger      = logFactory.NewLogger(F.ToString("provider/inline", "[", tag, "]"))
 	)
 	p := &ProviderLocal{
-		Adapter: provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeInline, options.HealthCheck),
+		Adapter: provider.NewAdapter(ctx, router, outbound, endpointMgr, logFactory, logger, tag, C.ProviderTypeInline, options.HealthCheck),
 		ctx:     ctx,
 		logger:  logger,
 	}
 	p.SetRemoveEmojis(options.RemoveEmojis)
 	p.UpdateOutbounds(nil, options.Outbounds)
+	if len(options.Endpoints) > 0 {
+		p.UpdateEndpoints(nil, options.Endpoints)
+	}
 	return p, nil
 }
 
@@ -61,11 +66,12 @@ func NewProviderLocal(ctx context.Context, router adapter.Router, logFactory log
 		return nil, E.New("provider path is required")
 	}
 	var (
-		outbound = service.FromContext[adapter.OutboundManager](ctx)
-		logger   = logFactory.NewLogger(F.ToString("provider/local", "[", tag, "]"))
+		outbound    = service.FromContext[adapter.OutboundManager](ctx)
+		endpointMgr = service.FromContext[adapter.EndpointManager](ctx)
+		logger      = logFactory.NewLogger(F.ToString("provider/local", "[", tag, "]"))
 	)
 	provider := &ProviderLocal{
-		Adapter:  provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeLocal, options.HealthCheck),
+		Adapter:  provider.NewAdapter(ctx, router, outbound, endpointMgr, logFactory, logger, tag, C.ProviderTypeLocal, options.HealthCheck),
 		ctx:      ctx,
 		logger:   logger,
 		provider: service.FromContext[adapter.ProviderManager](ctx),
@@ -117,12 +123,14 @@ func (s *ProviderLocal) reloadFile(path string) error {
 	if err != nil {
 		return err
 	}
-	outboundOpts, err := parser.ParseSubscription(s.ctx, string(content))
+	outboundOpts, endpointOpts, err := parser.ParseSubscription(s.ctx, string(content))
 	if err != nil {
 		return err
 	}
 	s.UpdateOutbounds(s.lastOutOpts, outboundOpts)
 	s.lastOutOpts = outboundOpts
+	s.UpdateEndpoints(s.lastEPOpts, endpointOpts)
+	s.lastEPOpts = endpointOpts
 	return nil
 }
 

--- a/provider/remote/provider.go
+++ b/provider/remote/provider.go
@@ -48,6 +48,7 @@ type ProviderRemote struct {
 	dialer           N.Dialer
 	lastEtag         string
 	lastOutOpts      []option.Outbound
+	lastEPOpts       []option.Endpoint
 	lastUpdated      time.Time
 	subscriptionInfo adapter.SubscriptionInfo
 	ticker           *time.Ticker
@@ -81,11 +82,12 @@ func NewProviderRemote(ctx context.Context, router adapter.Router, logFactory lo
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	outbound := service.FromContext[adapter.OutboundManager](ctx)
+	endpointMgr := service.FromContext[adapter.EndpointManager](ctx)
 	logger := logFactory.NewLogger(F.ToString("provider/remote", "[", tag, "]"))
 	updateChan := make(chan struct{})
 	close(updateChan)
 	p := &ProviderRemote{
-		Adapter:  provider.NewAdapter(ctx, router, outbound, logFactory, logger, tag, C.ProviderTypeRemote, options.HealthCheck),
+		Adapter:  provider.NewAdapter(ctx, router, outbound, endpointMgr, logFactory, logger, tag, C.ProviderTypeRemote, options.HealthCheck),
 		ctx:      ctx,
 		cancel:   cancel,
 		logger:   logger,
@@ -254,6 +256,7 @@ func (s *ProviderRemote) fetch(ctx context.Context) error {
 	if s.cacheFile != nil {
 		content, _ := json.Marshal(option.Options{
 			Outbounds: s.lastOutOpts,
+			Endpoints: s.lastEPOpts,
 		})
 		if hasInfo {
 			content = append([]byte(infoStr+"\n"), content...)
@@ -295,15 +298,20 @@ func (s *ProviderRemote) loopUpdate() {
 }
 
 func (s *ProviderRemote) updateProviderFromContent(content string) error {
-	outboundOpts, err := parser.ParseSubscription(s.ctx, content)
+	outboundOpts, endpointOpts, err := parser.ParseSubscription(s.ctx, content)
 	if err != nil {
 		return err
 	}
 	outboundOpts = common.Filter(outboundOpts, func(it option.Outbound) bool {
 		return (s.exclude == nil || !s.exclude.MatchString(it.Tag)) && (s.include == nil || s.include.MatchString(it.Tag))
 	})
+	endpointOpts = common.Filter(endpointOpts, func(it option.Endpoint) bool {
+		return (s.exclude == nil || !s.exclude.MatchString(it.Tag)) && (s.include == nil || s.include.MatchString(it.Tag))
+	})
 	s.UpdateOutbounds(s.lastOutOpts, outboundOpts)
 	s.lastOutOpts = outboundOpts
+	s.UpdateEndpoints(s.lastEPOpts, endpointOpts)
+	s.lastEPOpts = endpointOpts
 	return nil
 }
 


### PR DESCRIPTION
The source code is taken from [this author's commit](https://github.com/nekolsd/sing-box/commit/3b9d90aa4e79453401eabb15126fb14754017e4c) with my edits for a successful build and working feature.

The provider can now parse Clash (.yaml) and sing-box (.json) multiple WireGuard endpoint configurations.

The advantage is that you don’t have to constantly specify each WireGuard endpoints in the main Sing-Box configuration (which makes it more readable). You can spread them across `provider` subscriptions, and since `use_all_providers` is already exist, you can simply set this parameter in all `selector` and `urltest`, and all WireGuard configurations will be automatically loaded.

Tested with a 2 simple Cloudflare WARP configuration in a [local](https://github.com/shtorm-7/sing-box-extended/blob/extended/examples/provider/local.json) subscription.

Example of a local subscription file `sb-wg-sub.json` in sing-box JSON format 

```json
{
  "endpoints": [
    {
      "type": "wireguard",
      "tag": "👽 Proxy WARP (sing-box json)",
      "mtu": 1280,
      "private_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
      "address": [
        "172.16.0.2/32",
        "2606:4700:110:898a:1639:7b67:c36d:bcf9/128"
      ],
      "peers": [
        {
          "address": "xxx.xxx.xxx.x",
          "allowed_ips": ["0.0.0.0/0", "::/0"],
          "port": xxx,
          "public_key": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
          "persistent_keepalive_interval": 30
        }
      ]
    }
  ]
}
```

Example of a local subscription file `clash-wg-sub.yaml` in Clash YAML format

```yaml
proxies:
  - name: 👽 Proxy WARP (Clash yaml)
    type: wireguard
    server: xxx.xxx.xxx.x
    port: xxx
    private-key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
    public-key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
    ip: 172.16.0.2/32
    allowed-ips:
      - 0.0.0.0/0
      - ::/0
```