### PR TITLE
Fix xhttp packet-up tearing down all flows and VLESS UDP nil Close

### DIFF
--- a/protocol/vless/encryption/common.go
+++ b/protocol/vless/encryption/common.go
@@ -50,6 +50,13 @@ func NewCommonConn(conn net.Conn, useAES bool) *CommonConn {
 	}
 }
 
+func (c *CommonConn) Close() error {
+	if c == nil || c.Conn == nil {
+		return nil
+	}
+	return c.Conn.Close()
+}
+
 func (c *CommonConn) Write(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil

--- a/protocol/vless/outbound.go
+++ b/protocol/vless/outbound.go
@@ -214,10 +214,12 @@ func (h *vlessDialer) DialContext(ctx context.Context, network string, destinati
 	}
 
 	if h.encryption != nil {
-		conn, err = h.encryption.Handshake(conn)
-		if err != nil {
-			return nil, E.Cause(err, "encryption handshake")
+		encConn, encErr := h.encryption.Handshake(conn)
+		if encErr != nil {
+			common.Close(conn)
+			return nil, E.Cause(encErr, "encryption handshake")
 		}
+		conn = encConn
 	}
 
 	var visionBaseConn net.Conn
@@ -299,11 +301,12 @@ func (h *vlessDialer) ListenPacket(ctx context.Context, destination M.Socksaddr)
 		return nil, err
 	}
 	if h.encryption != nil {
-		conn, err = h.encryption.Handshake(conn)
-		if err != nil {
+		encConn, encErr := h.encryption.Handshake(conn)
+		if encErr != nil {
 			common.Close(conn)
-			return nil, E.Cause(err, "encryption handshake")
+			return nil, E.Cause(encErr, "encryption handshake")
 		}
+		conn = encConn
 	}
 	if h.xudp {
 		return h.client.DialEarlyXUDPPacketConn(conn, destination)

--- a/transport/v2rayxhttp/client.go
+++ b/transport/v2rayxhttp/client.go
@@ -47,6 +47,11 @@ type Client struct {
 	xmuxManager2    *XmuxManager
 }
 
+const (
+	maxPostPacketAttempts  = 3
+	postPacketRetryBackoff = 100 * time.Millisecond
+)
+
 func NewClient(ctx context.Context, logger log.ContextLogger, dialer N.Dialer, serverAddr M.Socksaddr, options option.V2RayXHTTPOptions, tlsConfig tls.Config) (adapter.V2RayClientTransport, error) {
 	if tlsConfig != nil && len(tlsConfig.NextProtos()) == 0 {
 		tlsConfig.SetNextProtos([]string{"h2"})
@@ -235,23 +240,46 @@ func (c *Client) DialContext(ctx context.Context) (net.Conn, error) {
 				}
 				lastWrite = time.Now()
 				if dynamicXmuxClient != nil && (dynamicXmuxClient.LeftRequests.Add(-1) <= 0 ||
+					dynamicXmuxClient.XmuxConn.IsClosed() ||
 					(dynamicXmuxClient.UnreusableAt != time.Time{} && lastWrite.After(dynamicXmuxClient.UnreusableAt))) {
 					dynamicHTTPClient, dynamicXmuxClient = c.getHTTPClient()
 				}
-				go func(hClient DialerClient) {
-					err := hClient.PostPacket(
-						ctx,
-						requestURL.String(),
-						sessionId,
-						seqStr,
-						chunk,
-					)
+				payloadBytes := make([]byte, chunk.Len())
+				chunk.Copy(payloadBytes)
+				go func(hClient DialerClient, hXmux *XmuxClient) {
+					if hXmux != nil {
+						hXmux.AddOpenUsage(1)
+					}
+					err := hClient.PostPacket(ctx, requestURL.String(), sessionId, seqStr, chunk)
+					for attempt := 1; err != nil && attempt < maxPostPacketAttempts; attempt++ {
+						if ctx.Err() != nil {
+							break
+						}
+						if hXmux != nil {
+							hXmux.AddOpenUsage(-1)
+						}
+						hClient, hXmux = c.getHTTPClient()
+						if hXmux != nil {
+							hXmux.AddOpenUsage(1)
+						}
+						chunk = buf.MergeBytes(nil, payloadBytes)
+						timer := time.NewTimer(time.Duration(attempt) * postPacketRetryBackoff)
+						select {
+						case <-timer.C:
+						case <-ctx.Done():
+							timer.Stop()
+						}
+						err = hClient.PostPacket(ctx, requestURL.String(), sessionId, seqStr, chunk)
+					}
+					if hXmux != nil {
+						hXmux.AddOpenUsage(-1)
+					}
 					wroteRequest.Close()
 					if err != nil {
 						uploadPipeReader.Interrupt()
 						doSplit.Store(false)
 					}
-				}(dynamicHTTPClient)
+				}(dynamicHTTPClient, dynamicXmuxClient)
 				if _, ok := dynamicHTTPClient.(*DefaultDialerClient); ok {
 					<-wroteRequest.Wait()
 				}

--- a/transport/v2rayxhttp/dialer.go
+++ b/transport/v2rayxhttp/dialer.go
@@ -95,6 +95,12 @@ func (c *DefaultDialerClient) IsClosed() bool {
 	return c.closed
 }
 
+func (c *DefaultDialerClient) MarkUnusable() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.closed = true
+}
+
 func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr net.Addr, err error) {
 	// this is done when the TCP/UDP connection to the server was established,
 	// and we can unblock the Dial function and print correct net addresses in
@@ -120,7 +126,7 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 		resp, err = c.client.Do(req)
 		if err != nil {
 			if !uploadOnly && !errors.Is(err, context.Canceled) { // stream-down is enough
-				c.Close()
+				c.MarkUnusable()
 			}
 			cancel()
 			gotConn.Close()
@@ -152,7 +158,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	if c.httpVersion != "1.1" {
 		resp, err := c.client.Do(req)
 		if err != nil {
-			c.Close()
+			c.MarkUnusable()
 			return err
 		}
 		io.Copy(io.Discard, resp.Body)
@@ -188,7 +194,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 				if h1UploadConn.UnreadedResponsesCount > 0 {
 					resp, err := http.ReadResponse(h1UploadConn.RespBufReader, req)
 					if err != nil {
-						c.Close()
+						c.MarkUnusable()
 						return fmt.Errorf("error while reading response: %s", err.Error())
 					}
 					io.Copy(io.Discard, resp.Body)


### PR DESCRIPTION
A failed xhttp POST used to Close() the shared h2 transport and kill the long-lived GET download. Mark the client unusable instead and retry the POST. Also avoid assigning a typed-nil *CommonConn when the encryption handshake fails, which panics ListenPacket on TUN UDP.